### PR TITLE
Сделать верх страницы /exhibition компактным без hero-заглушки

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1010,6 +1010,20 @@
             max-width: 640px;
         }
 
+        /* ── Exhibition page: compact top block ── */
+        #page-exhibition .page-hero {
+            padding: 112px 48px 36px;
+        }
+        #page-exhibition .page-hero .hero-texture {
+            display: none;
+        }
+        #page-exhibition .breadcrumbs {
+            padding: 14px 48px;
+        }
+        #page-exhibition .content-section:first-of-type {
+            padding-top: 48px;
+        }
+
         /* ── Breadcrumbs ── */
         .breadcrumbs {
             padding: 20px 48px;
@@ -1694,6 +1708,9 @@
             .page-hero { padding: 120px 24px 56px; }
             .breadcrumbs { padding: 16px 24px; }
             .content-section { padding: 56px 24px; }
+            #page-exhibition .page-hero { padding: 104px 24px 28px; }
+            #page-exhibition .breadcrumbs { padding: 12px 24px; }
+            #page-exhibition .content-section:first-of-type { padding-top: 36px; }
             .content-two-col { grid-template-columns: 1fr; gap: 40px; }
             .catalog-grid { grid-template-columns: 1fr 1fr; }
             .work-single-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
### Motivation
- Текущая внутренняя страница «Выставка» (`#/exhibition`) начинается с большого декоративного hero-блока, создающего ощущение лендинга и лишнего пустого пространства. 
- Нужно минимальным и безопасным правком убрать визуальную заглушку и сделать верх страницы компактным, сохранив тексты и структуру страниц.

### Description
- Внесён scoped CSS-патч в `styles.css`, ограниченный селектором `#page-exhibition`, чтобы не затрагивать другие страницы. 
- Уменьшены верхний и нижний отступы у верхнего блока (`#page-exhibition .page-hero`) и добавлены соответствующие mobile-override’ы для экранов до `900px`. 
- Отключена декоративная текстура `.hero-texture` только для `#page-exhibition` и уменьшены паддинги у breadcrumbs на этой странице. 
- Уменьшен верхний отступ у первого контентного блока на странице (`#page-exhibition .content-section:first-of-type`), чтобы после breadcrumbs сразу шёл блок «Концепция». 

### Testing
- Проверена итоговая разница в репозитории и что изменён только один файл: `styles.css` (diff проверен через средство сравнения файла). — успешно. 
- Локально просмотрены фрагменты `index.html` рядом с `#page-exhibition`, чтобы убедиться, что разделы «Концепция», «Структура экспозиции» и «Физическое и цифровое» остались на месте; структура не менялась. — успешно. 
- Добавленные CSS-правила применяются в desktop и mobile-брейкпоинтах и не влияют на другие страницы благодаря селекторам по `#page-exhibition`; автоматических тестов визуального рендеринга в среде нет (мануальная проверка в браузере рекомендована). — не применялось/не выполнялось (нет GUI-теста).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c63ce424f883228d598e0a8de60b5d)