### PR TITLE
Artist dossier redesign, layout & style refinements; add artwork aspect ratio and print rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,13 +89,9 @@
                 <div class="hero-visual-frame">
                     <div class="hero-visual-inner">
                         <i class="fa-solid fa-image"></i>
-                        <span>Фрагмент живописи из коллекции</span>
+                        <span>Фрагмент живописи</span>
                     </div>
                 </div>
-            </div>
-            <div class="hero-scroll">
-                <span>Далее</span>
-                <div class="hero-scroll-line"></div>
             </div>
         </section>
 
@@ -115,7 +111,6 @@
         <section class="section-cool">
             <div class="container">
                 <div class="section-header reveal">
-                    <div class="section-number dark">01</div>
                     <h2 class="section-title dark">О художнике</h2>
                     <div class="divider gold"></div>
                 </div>
@@ -142,7 +137,6 @@
         <section class="section-dark">
             <div class="container">
                 <div class="section-header reveal">
-                    <div class="section-number light">02</div>
                     <h2 class="section-title light">О выставке</h2>
                     <div class="divider gold"></div>
                 </div>
@@ -159,7 +153,6 @@
         <section class="section-light">
             <div class="container">
                 <div class="section-header reveal">
-                    <div class="section-number dark">03</div>
                     <h2 class="section-title dark">Избранные работы</h2>
                     <div class="divider burgundy"></div>
                     <p class="section-lead dark">Четыре работы для первого знакомства с северной, городской и волжской линиями искусства Овчинникова.</p>
@@ -173,7 +166,7 @@
                         </div>
                         <h4 style="color: var(--deep-blue);">Северный пейзаж</h4>
                         <span class="work-meta" style="color: var(--text-muted);">А.Л. Овчинников · 1998 · 80 x 120 см</span>
-                    </div>
+                    </a>
                     <a class="work-card" href="#/works/vecherniy-svet-vologda" data-route="/works/vecherniy-svet-vologda" style="text-decoration: none;">
                         <div class="work-image">
                             <div class="work-image-inner">
@@ -182,7 +175,7 @@
                         </div>
                         <h4 style="color: var(--deep-blue);">Вечерний свет. Вологда</h4>
                         <span class="work-meta" style="color: var(--text-muted);">А.Л. Овчинников · 2005 · 60 x 90 см</span>
-                    </div>
+                    </a>
                     <a class="work-card" href="#/works/zimniy-den-v-peterburge" data-route="/works/zimniy-den-v-peterburge" style="text-decoration: none;">
                         <div class="work-image">
                             <div class="work-image-inner">
@@ -191,7 +184,7 @@
                         </div>
                         <h4 style="color: var(--deep-blue);">Зимний день в Петербурге</h4>
                         <span class="work-meta" style="color: var(--text-muted);">А.Л. Овчинников · 2010 · 50 x 70 см</span>
-                    </div>
+                    </a>
                     <a class="work-card" href="#/works/nizhegorodskie-dali" data-route="/works/nizhegorodskie-dali" style="text-decoration: none;">
                         <div class="work-image">
                             <div class="work-image-inner">
@@ -212,7 +205,6 @@
         <section class="section-dark">
             <div class="container">
                 <div class="section-header reveal">
-                    <div class="section-number light">04</div>
                     <h2 class="section-title light">Цифровое пространство</h2>
                     <div class="divider gold"></div>
                 </div>
@@ -223,7 +215,7 @@
                         </div>
                         <h4>Виртуальный зал</h4>
                         <p>Посетите выставку онлайн в формате 360°.</p>
-                        <a href="#/digital" data-route="/digital" class="btn btn-gold">Подробнее</a>
+                        <a href="#/digital" data-route="/digital" class="btn btn-white">Подробнее</a>
                     </div>
                     <a class="digital-block" href="#/digital/animated" data-route="/digital/animated" style="text-decoration: none; color: inherit;">
                         <div class="digital-block-icon">
@@ -231,7 +223,7 @@
                         </div>
                         <h4>Ожившие полотна</h4>
                         <p>Статичные пейзажи обретают движение и звук.</p>
-                        <span class="btn btn-gold">Смотреть</span>
+                        <span class="btn btn-white">Смотреть</span>
                     </a>
                     <a class="digital-block" href="#/digital/workshop" data-route="/digital/workshop" style="text-decoration: none; color: inherit;">
                         <div class="digital-block-icon">
@@ -239,7 +231,7 @@
                         </div>
                         <h4>3D-мастерская</h4>
                         <p>Виртуальная реконструкция мастерской художника.</p>
-                        <span class="btn btn-gold">Перейти</span>
+                        <span class="btn btn-white">Перейти</span>
                     </a>
                 </div>
             </div>
@@ -262,7 +254,6 @@
         <section class="section-cool">
             <div class="container">
                 <div class="section-header reveal">
-                    <div class="section-number dark">05</div>
                     <h2 class="section-title dark">Посещение</h2>
                     <div class="divider gold"></div>
                 </div>
@@ -296,7 +287,7 @@
             <div class="container">
                 <div class="page-hero-label">О художнике</div>
                 <h1>Александр Львович <em>Овчинников</em></h1>
-                <div class="page-hero-subtitle">Личность, школа, семейный контекст, наследие</div>
+                <div class="page-hero-subtitle">Досье выставки: художественный путь, география, метод, семейная преемственность и архив</div>
             </div>
         </div>
 
@@ -308,104 +299,230 @@
             </div>
         </div>
 
-        <!-- Вводный блок -->
-        <section class="content-section bg-cool">
-            <div class="content-block reveal">
-                <div class="content-two-col">
-                    <div class="artist-portrait">
-                        <div class="artist-portrait-placeholder">
-                            <i class="fa-solid fa-image-portrait"></i>
-                            <span></span>
+        <section class="content-section bg-cool" id="artist-intro">
+            <div class="content-block reveal artist-dossier-layout">
+                <aside class="artist-toc" aria-label="Оглавление страницы художника">
+                    <h3>Содержание</h3>
+                    <button type="button" onclick="document.getElementById('artist-life-geo').scrollIntoView({behavior:'smooth', block:'start'});">Жизнь и география</button>
+                    <button type="button" onclick="document.getElementById('artist-north').scrollIntoView({behavior:'smooth', block:'start'});">Русский Север</button>
+                    <button type="button" onclick="document.getElementById('artist-method').scrollIntoView({behavior:'smooth', block:'start'});">Как он работал</button>
+                    <button type="button" onclick="document.getElementById('artist-index').scrollIntoView({behavior:'smooth', block:'start'});">Круг мотивов</button>
+                    <button type="button" onclick="document.getElementById('artist-family').scrollIntoView({behavior:'smooth', block:'start'});">Отец и сын</button>
+                    <button type="button" onclick="document.getElementById('artist-archive').scrollIntoView({behavior:'smooth', block:'start'});">Архивный кабинет</button>
+                    <button type="button" onclick="document.getElementById('artist-workshop').scrollIntoView({behavior:'smooth', block:'start'});">Мастерская</button>
+                    <button type="button" onclick="document.getElementById('artist-etude').scrollIntoView({behavior:'smooth', block:'start'});">Незавершённое и этюдное</button>
+                    <button type="button" onclick="document.getElementById('artist-legacy').scrollIntoView({behavior:'smooth', block:'start'});">Наследие</button>
+                </aside>
+                <div class="artist-intro-main">
+                    <div class="artist-intro-headline">«Смотреть Овчинникова важно не как художника одной темы, а как мастера большого национального пространства»</div>
+                    <div class="artist-intro-grid">
+                        <div class="artist-portrait">
+                            <div class="artist-portrait-placeholder">
+                                <i class="fa-solid fa-image-portrait"></i>
+                                <span>Архивный портрет</span>
+                            </div>
+                            <div class="artist-portrait-frame"></div>
                         </div>
-                        <div class="artist-portrait-frame"></div>
+                        <div class="artist-intro-text">
+                            <p>Александр Львович Овчинников — художник, в творчестве которого академическая школа, историческая память и живое чувство национального пространства соединились в цельный художественный мир. Русский Север составляет центральную и наиболее последовательно разработанную тему его искусства, однако ею его творчество не исчерпывается.</p>
+                            <p>Наряду с северным циклом в наследии мастера важное место занимают историческая тема, городской и архитектурный пейзаж, камерный интерьер, предметный мир русской культуры, южные впечатления, графика и дальние художественные маршруты.</p>
+                        </div>
                     </div>
-                    <div>
-                        <div class="quote">«Смотреть Овчинникова важно не как художника одной темы, а как мастера большого национального пространства»</div>
-                        <p class="dark" style="font-family: var(--sans); font-size: 15px; font-weight: 300; color: var(--text-muted); line-height: 1.8;">Александр Львович Овчинников — художник, в творчестве которого академическая школа, историческая память и живое чувство национального пространства соединились в цельный художественный мир. Русский Север составляет центральную и наиболее последовательно разработанную тему его искусства, однако ею его творчество не исчерпывается.</p>
-                        <p style="font-family: var(--sans); font-size: 15px; font-weight: 300; color: var(--text-muted); line-height: 1.8;">Наряду с северным циклом в наследии мастера важное место занимают историческая тема, городской и архитектурный пейзаж, камерный интерьер, предметный мир русской культуры, южные впечатления, графика и дальние художественные маршруты.</p>
-                    </a>
                 </div>
             </div>
         </section>
 
-        <!-- Художественный путь -->
-        <section class="content-section bg-light">
+        <section class="content-section bg-light" id="artist-life-geo">
             <div class="content-block reveal">
-                <h2 class="dark">Художественный путь</h2>
+                <h2 class="dark">Жизнь и география</h2>
+                <div class="subtitle dark">Художественный путь и маршруты как единая линия</div>
                 <div class="divider gold"></div>
-                <div class="content-two-col" style="margin-top: 40px;">
-                    <div class="timeline">
-                        <div class="timeline-item">
-                            <div class="year">1956</div>
-                            <h4>Рождение</h4>
-                            <p>Родился 26 апреля 1956 года. Рос в семье художника Льва Авксентьевича Овчинникова.</p>
-                        </div>
-                        <div class="timeline-item">
-                            <div class="year">1970-е</div>
-                            <h4>Становление</h4>
-                            <p>Обучение в художественной школе, первые поездки на Русский Север, формирование творческого метода.</p>
-                        </div>
-                        <div class="timeline-item">
-                            <div class="year">1980-е</div>
-                            <h4>Академическая школа</h4>
-                            <p>Институт имени И.Е. Репина. Углублённая работа с историческим пейзажем и архитектурной темой.</p>
-                        </div>
-                        <div class="timeline-item">
-                            <div class="year">1990–2000-е</div>
-                            <h4>Зрелый период</h4>
-                            <p>Масштабные северные циклы, городские серии, волжские и южные впечатления. Линогравюра.</p>
-                        </div>
-                        <div class="timeline-item">
-                            <div class="year">2010-е</div>
-                            <h4>Позднее творчество</h4>
-                            <p>Камерные работы, интерьеры, предметный мир. Осмысление пространства памяти.</p>
+                <div class="artist-life-geo-grid" style="margin-top: 40px;">
+                    <div class="artist-module">
+                        <h3 class="dark">Хронология</h3>
+                        <div class="timeline">
+                            <div class="timeline-item">
+                                <div class="year">1956</div>
+                                <h4>Рождение</h4>
+                                <p>Родился 26 апреля 1956 года. Рос в семье художника Льва Авксентьевича Овчинникова.</p>
+                            </div>
+                            <div class="timeline-item">
+                                <div class="year">1970-е</div>
+                                <h4>Становление</h4>
+                                <p>Обучение в художественной школе, первые поездки на Русский Север, формирование творческого метода.</p>
+                            </div>
+                            <div class="timeline-item">
+                                <div class="year">1980-е</div>
+                                <h4>Академическая школа</h4>
+                                <p>Институт имени И.Е. Репина. Углублённая работа с историческим пейзажем и архитектурной темой.</p>
+                            </div>
+                            <div class="timeline-item">
+                                <div class="year">1990–2000-е</div>
+                                <h4>Зрелый период</h4>
+                                <p>Масштабные северные циклы, городские серии, волжские и южные впечатления. Линогравюра.</p>
+                            </div>
+                            <div class="timeline-item">
+                                <div class="year">2010-е</div>
+                                <h4>Позднее творчество</h4>
+                                <p>Камерные работы, интерьеры, предметный мир. Осмысление пространства памяти.</p>
+                            </div>
                         </div>
                     </div>
-                    <div>
-                        <p style="font-family: var(--sans); font-size: 15px; font-weight: 300; color: var(--text-muted); line-height: 1.8;">Его искусство соединяет эпическое и камерное, декоративное и этюдное, народно-поэтическое и академически выверенное. Поэтому смотреть Овчинникова важно не как художника одной темы, а как мастера большого национального пространства, где Север, русский город, дом, история, вещь и память существуют в единой образной системе.</p>
-                        <p style="font-family: var(--sans); font-size: 15px; font-weight: 300; color: var(--text-muted); line-height: 1.8;">Работа на натуре была для него не этапом подготовки, а самостоятельным творческим актом. Этюды с натуры, выполненные в экспедициях по Русскому Северу, обладают той же степенью завершённости и образной силы, что и большие станковые композиции.</p>
+                    <div class="artist-module">
+                        <h3 class="dark">География творчества</h3>
+                        <p class="dark">От Русского Севера до Нижнего Новгорода, Васильсурска, Алупки и других удалённых мест — география его искусства показывает художника не одной темы, а большого национального и пространственного диапазона.</p>
+                        <p class="dark">Каждое место становилось для него не просто мотивом, а пространством, в котором проявлялась историческая и культурная память.</p>
+                        <div class="artist-map-placeholder">
+                            <i class="fa-solid fa-map"></i>
+                            <span>Карта маршрутов художника</span>
+                        </div>
                     </div>
                 </div>
             </div>
         </section>
 
-        <!-- Семейный контекст -->
-        <section class="content-section bg-cool">
+        <section class="content-section bg-cool" id="artist-north">
             <div class="content-block reveal">
-                <h2 class="dark">Семейный контекст</h2>
-                <div class="subtitle dark">Преемственность поколений</div>
+                <h2 class="dark">Русский Север</h2>
+                <div class="subtitle dark">Главная духовная ось творчества</div>
                 <div class="divider gold"></div>
-                <div class="content-narrow" style="margin-top: 32px;">
-                    <p style="font-family: var(--sans); font-size: 15px; font-weight: 300; color: var(--text-muted); line-height: 1.8;">Выставка «Пространство памяти» объединяет произведения двух поколений — Льва Авксентьевича и Александра Львовича Овчинниковых. Это не просто семейная преемственность, а передача художественного метода, отношения к натуре и понимания национального пространства.</p>
-                    <p style="font-family: var(--sans); font-size: 15px; font-weight: 300; color: var(--text-muted); line-height: 1.8;">Лев Авксентьевич Овчинников — художник старшего поколения, чьё творчество было связано с традицией русского реалистического пейзажа. Его сын продолжил и развил эту линию, придав ей новый масштаб и глубину.</p>
-                </div>
-            </div>
-        </section>
-
-        <!-- Маршруты -->
-        <section class="content-section bg-burgundy">
-            <div class="content-block reveal">
-                <div class="geo-inner" style="max-width: 100%;">
-                    <div class="geo-text" style="max-width: 100%; text-align: left;">
-                        <h3>География творчества</h3>
-                        <p>От Русского Севера до Нижнего Новгорода, Васильсурска, Алупки и других удалённых мест — география его искусства показывает художника не одной темы, а большого национального и пространственного диапазона.</p>
-                        <p>Каждое место становилось для него не просто мотивом, а пространством, в котором проявлялась историческая и культурная память.</p>
+                <div class="artist-focus-grid" style="margin-top: 36px;">
+                    <div>
+                        <p class="dark">Его искусство соединяет эпическое и камерное, декоративное и этюдное, народно-поэтическое и академически выверенное. Поэтому смотреть Овчинникова важно не как художника одной темы, а как мастера большого национального пространства, где Север, русский город, дом, история, вещь и память существуют в единой образной системе.</p>
+                        <p class="dark">Работа на натуре была для него не этапом подготовки, а самостоятельным творческим актом. Этюды с натуры, выполненные в экспедициях по Русскому Северу, обладают той же степенью завершённости и образной силы, что и большие станковые композиции.</p>
+                    </div>
+                    <div class="artist-focus-card">
+                        <div class="artist-focus-image">
+                            <i class="fa-solid fa-mountain-sun"></i>
+                            <span>Фокусный мотив северного цикла</span>
+                        </div>
+                        <h4>Работа в фокусе</h4>
+                        <p>Северный пейзаж в этом разделе понимается как пространство памяти, в котором натура, история и архитектура соединяются в едином образе.</p>
                     </div>
                 </div>
             </div>
         </section>
 
-        <!-- Наследие -->
-        <section class="content-section bg-light">
+        <section class="content-section bg-light" id="artist-method">
+            <div class="content-block reveal">
+                <h2 class="dark">Как он работал</h2>
+                <div class="subtitle dark">Процесс: от натуры к завершённой форме</div>
+                <div class="divider gold"></div>
+                <div class="artist-method-grid" style="margin-top: 36px;">
+                    <article class="artist-method-item">
+                        <h4>Натура</h4>
+                        <p>Полевые поездки и живое наблюдение оставались постоянной опорой его метода.</p>
+                    </article>
+                    <article class="artist-method-item">
+                        <h4>Этюд</h4>
+                        <p>Этюд рассматривался как самостоятельный художественный акт, а не только подготовка.</p>
+                    </article>
+                    <article class="artist-method-item">
+                        <h4>Мастерская</h4>
+                        <p>Материал натуры проходил через мастерскую как пространство медленного анализа и сборки композиции.</p>
+                    </article>
+                    <article class="artist-method-item">
+                        <h4>Завершённая работа</h4>
+                        <p>Большая форма сохраняла точность натурного наблюдения, но расширялась до исторического масштаба.</p>
+                    </article>
+                    <article class="artist-method-item">
+                        <h4>Графика</h4>
+                        <p>Линогравюра и рисунок развивали ту же образную систему в иной пластике и ритме.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="content-section bg-cool" id="artist-index">
+            <div class="content-block reveal">
+                <h2 class="dark">Круг мотивов</h2>
+                <div class="subtitle dark">Тематический индекс</div>
+                <div class="divider gold"></div>
+                <div class="artist-index-list" style="margin-top: 32px;">
+                    <span>Русский Север</span>
+                    <span>Русский город</span>
+                    <span>Историческая тема</span>
+                    <span>Интерьер</span>
+                    <span>Предметный мир</span>
+                    <span>Волга и Юг</span>
+                    <span>Графика</span>
+                </div>
+            </div>
+        </section>
+
+        <section class="content-section bg-light" id="artist-family">
+            <div class="content-block reveal">
+                <h2 class="dark">Отец и сын</h2>
+                <div class="subtitle dark">Семейный контекст как диптих</div>
+                <div class="divider gold"></div>
+                <div class="artist-diptych" style="margin-top: 36px;">
+                    <article class="artist-diptych-card">
+                        <h4>Лев Авксентьевич Овчинников</h4>
+                        <p>Художник старшего поколения, чьё творчество было связано с традицией русского реалистического пейзажа.</p>
+                        <ul>
+                            <li>Передаётся: школа, отношение к натуре, культурная память пейзажа.</li>
+                            <li>Линия основы: дисциплина формы и реалистическая традиция.</li>
+                        </ul>
+                    </article>
+                    <article class="artist-diptych-card">
+                        <h4>Александр Львович Овчинников</h4>
+                        <p>Продолжил и развил семейную линию, придав ей новый масштаб и пространственную глубину.</p>
+                        <ul>
+                            <li>Меняется: диапазон маршрутов, тематическая широта, акцент на пространстве памяти.</li>
+                            <li>Самостоятельность: расширение темы от Севера к городу, истории, интерьеру, графике.</li>
+                        </ul>
+                    </article>
+                </div>
+                <p class="dark" style="margin-top: 28px;">Выставка «Пространство памяти» объединяет произведения двух поколений — Льва Авксентьевича и Александра Львовича Овчинниковых. Это не просто семейная преемственность, а передача художественного метода, отношения к натуре и понимания национального пространства.</p>
+            </div>
+        </section>
+
+        <section class="content-section bg-cool" id="artist-archive">
+            <div class="content-block reveal">
+                <h2 class="dark">Архивный кабинет</h2>
+                <div class="subtitle dark">Рабочий архив художника</div>
+                <div class="divider gold"></div>
+                <div class="artist-archive-grid" style="margin-top: 32px;">
+                    <div class="artist-archive-item"><i class="fa-solid fa-file-lines"></i><span>Документы</span></div>
+                    <div class="artist-archive-item"><i class="fa-solid fa-camera"></i><span>Фотографии</span></div>
+                    <div class="artist-archive-item"><i class="fa-solid fa-book"></i><span>Записные книжки</span></div>
+                    <div class="artist-archive-item"><i class="fa-solid fa-envelope-open-text"></i><span>Письма</span></div>
+                    <div class="artist-archive-item"><i class="fa-solid fa-layer-group"></i><span>Листы и эскизы</span></div>
+                    <div class="artist-archive-item"><i class="fa-solid fa-box-archive"></i><span>Рабочие материалы</span></div>
+                </div>
+            </div>
+        </section>
+
+        <section class="content-section bg-light" id="artist-workshop">
+            <div class="content-block reveal">
+                <h2 class="dark">Мастерская как автопортрет</h2>
+                <div class="divider gold"></div>
+                <div class="artist-workshop-entry">
+                    <p class="dark">Мастерская художника сохранена как мемориальное пространство. В её устройстве читается биография метода: натурные этюды, рабочие состояния, инструменты и материалы складываются в автопортрет художника, созданный не словами, а вещами и следами работы.</p>
+                    <a href="#/digital/workshop" data-route="/digital/workshop" class="btn btn-light">Перейти в 3D-мастерскую</a>
+                </div>
+            </div>
+        </section>
+
+        <section class="content-section bg-cool" id="artist-etude">
+            <div class="content-block reveal">
+                <h2 class="dark">Незавершённое и этюдное</h2>
+                <div class="subtitle dark">Рабочие состояния как часть наследия</div>
+                <div class="divider gold"></div>
+                <div class="artist-etude-note">
+                    <p class="dark">Незавершённые вещи, этюды и промежуточные состояния показывают живой ход работы: как формируется композиция, как уточняется цветовая среда, как меняется масштаб замысла от листа к большому полотну.</p>
+                    <p class="dark">Этот слой важен не меньше завершённых произведений, поскольку позволяет увидеть внутреннюю лабораторию художника и ритм его мышления.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="content-section bg-light" id="artist-legacy">
             <div class="content-block reveal">
                 <h2 class="dark">Наследие</h2>
                 <div class="divider gold"></div>
                 <div class="content-narrow" style="margin-top: 32px;">
-                    <p style="font-family: var(--sans); font-size: 15px; font-weight: 300; color: var(--text-muted); line-height: 1.8;">Наследие Александра Овчинникова — это не только корпус произведений, но и художественный метод, который может быть осмыслен и продолжен. Мастерская художника сохранена как мемориальное пространство. Цифровой архив и виртуальная реконструкция мастерской позволяют познакомиться с его творческим процессом.</p>
-                    <div style="margin-top: 32px; display: flex; gap: 16px; flex-wrap: wrap;">
-                        <a href="#/works" data-route="/works" class="btn btn-burgundy">Смотреть работы</a>
-                        <a href="#/digital/workshop" data-route="/digital/workshop" class="btn btn-light">3D-мастерская</a>
-                    </div>
+                    <p>Наследие Александра Овчинникова — это не только корпус произведений, но и художественный метод, который может быть осмыслен и продолжен.</p>
+                    <p>Сегодня память о художнике поддерживается в нескольких взаимосвязанных формах: выставочная работа, сохранение мастерской, каталогизация произведений, цифровой архив и виртуальная реконструкция пространства мастерской.</p>
                 </div>
             </div>
         </section>
@@ -693,6 +810,7 @@
                     <div class="work-single-image">
                         <div class="work-single-image-inner">
                             <i class="fa-solid fa-image" id="workSingleIcon"></i>
+                            <span>Произведение из коллекции</span>
                         </div>
                     </div>
                     <div class="work-single-info">
@@ -812,10 +930,10 @@
         <section class="content-section bg-cool">
             <div class="content-block reveal">
                 <h2 class="dark">Цифровой архив</h2>
-                <div class="subtitle dark">Раздел в разработке</div>
+                <div class="subtitle dark">Материалы пополняются</div>
                 <div class="divider gold"></div>
                 <div class="content-narrow" style="margin-top: 32px;">
-                    <p style="font-family: var(--sans); font-size: 15px; font-weight: 300; color: var(--text-muted); line-height: 1.8;">Цифровой архив будет включать документы, фотографии, письма и другие материалы, связанные с жизнью и творчеством художника. Этот раздел находится в стадии подготовки и будет дополняться по мере оцифровки материалов.</p>
+                    <p style="font-family: var(--sans); font-size: 15px; font-weight: 300; color: var(--text-muted); line-height: 1.8;">Цифровой архив будет включать документы, фотографии, письма и другие материалы, связанные с жизнью и творчеством художника. Раздел будет дополнен по мере оцифровки материалов.</p>
                 </div>
             </div>
         </section>
@@ -1070,17 +1188,6 @@
                         <i class="fa-solid fa-map-location-dot" style="color: var(--gold-muted);"></i>
                         <span style="color: var(--text-light);">Схема расположения · Большая Морская ул., д. 38</span>
                     </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Цифровая версия -->
-        <section class="content-section bg-cool">
-            <div class="content-block reveal" style="text-align: center; max-width: 640px; margin: 0 auto;">
-                <h2 class="dark" style="font-size: 28px;">Не можете приехать?</h2>
-                <p style="font-family: var(--sans); font-size: 15px; font-weight: 300; color: var(--text-muted); line-height: 1.8; margin-top: 16px;">Посетите выставку в цифровом пространстве: виртуальный зал, ожившие полотна и 3D-мастерская доступны онлайн.</p>
-                <div style="margin-top: 28px;">
-                    <a href="#/digital" data-route="/digital" class="btn btn-burgundy">Цифровое пространство</a>
                 </div>
             </div>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,7 @@
             --text-on-dark: #E8E4DF;
             --border-light: rgba(0,0,0,0.08);
             --border-dark: rgba(255,255,255,0.1);
+            --artwork-ratio: 4/5;
             --serif: 'Playfair Display', 'Georgia', serif;
             --sans: 'Inter', -apple-system, sans-serif;
         }
@@ -130,8 +131,9 @@
             transition: all 0.25s ease;
         }
         .nav-btn:hover {
-            background: var(--gold);
-            color: var(--deep-blue);
+            background: rgba(198,150,83,0.12);
+            border-color: var(--gold);
+            color: #E8D3B7;
         }
 
         .nav-burger {
@@ -287,7 +289,7 @@
             align-self: center;
         }
         .hero-visual-frame {
-            aspect-ratio: 3/4;
+            aspect-ratio: var(--artwork-ratio);
             background: var(--deep-blue-light);
             border-radius: 2px;
             display: flex;
@@ -396,6 +398,7 @@
         }
         .section-number.light { color: var(--gold); }
         .section-number.dark { color: var(--text-muted); }
+        .section-number { display: none; }
         .section-title {
             font-family: var(--serif);
             font-size: clamp(28px, 4vw, 48px);
@@ -539,10 +542,10 @@
             cursor: default;
             transition: transform 0.3s ease;
         }
-        .work-card:hover { transform: translateY(-4px); }
-        .work-card:hover .work-image { box-shadow: 0 16px 48px rgba(0,0,0,0.12); }
+        .work-card:hover { transform: translateY(-1px); }
+        .work-card:hover .work-image { box-shadow: 0 10px 24px rgba(0,0,0,0.08); }
         .work-image {
-            aspect-ratio: 4/5;
+            aspect-ratio: var(--artwork-ratio);
             background: var(--deep-blue);
             border-radius: 2px;
             margin-bottom: 14px;
@@ -601,6 +604,11 @@
             border-radius: 2px;
             display: flex;
             flex-direction: column;
+            transition: border-color 0.2s ease, background-color 0.2s ease;
+        }
+        .digital-block:hover {
+            border-color: rgba(255,255,255,0.25);
+            background: rgba(255,255,255,0.06);
         }
         .digital-block-icon {
             width: 48px;
@@ -907,11 +915,41 @@
             opacity: 0.35;
         }
 
+        @media print {
+            #canvas,
+            .nav,
+            .mobile-menu,
+            .hero-scroll {
+                display: none !important;
+            }
+            .page {
+                display: none !important;
+                min-height: auto !important;
+            }
+            .page.active {
+                display: block !important;
+            }
+            body {
+                background: #fff !important;
+            }
+            .footer {
+                position: static !important;
+            }
+        }
+
         /* ── Responsive ── */
         @media (max-width: 1024px) {
             .digital-blocks { grid-template-columns: 1fr; }
             .digital-studio { grid-template-columns: 1fr; }
             .works-grid { grid-template-columns: repeat(2, 1fr); }
+            .artist-dossier-layout,
+            .artist-intro-grid,
+            .artist-life-geo-grid,
+            .artist-focus-grid,
+            .artist-diptych { grid-template-columns: 1fr; }
+            .artist-method-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+            .artist-archive-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+            .artist-toc { position: static; }
         }
         @media (max-width: 900px) {
             .nav { padding: 0 24px; }
@@ -923,7 +961,7 @@
                 padding: 120px 24px 60px;
             }
             .hero-visual { order: -1; }
-            .hero-visual-frame { aspect-ratio: 16/10; }
+            .hero-visual-frame { aspect-ratio: var(--artwork-ratio); }
             .hero-scroll { display: none; }
             .section-light, .section-dark, .section-cool, .section-burgundy { padding: 80px 24px; }
             .artist-grid,
@@ -934,11 +972,15 @@
             .footer-top { grid-template-columns: 1fr; gap: 32px; }
             .footer-nav { justify-self: start; }
             .geo-inner { flex-direction: column; text-align: center; }
+            .artist-intro-main { padding: 22px; }
+            .artist-index-list { grid-template-columns: 1fr; }
         }
         @media (max-width: 560px) {
             .works-grid { grid-template-columns: 1fr; }
             .hero-buttons { flex-direction: column; }
             .hero-buttons .btn { width: 100%; justify-content: center; }
+            .artist-method-grid { grid-template-columns: 1fr; }
+            .artist-archive-grid { grid-template-columns: 1fr; }
         }
 
         /* ── Page transitions ── */
@@ -1008,6 +1050,13 @@
             color: var(--text-light);
             line-height: 1.4;
             max-width: 640px;
+        }
+        #page-exhibition .page-hero {
+            padding-top: 120px;
+            padding-bottom: 48px;
+        }
+        #page-exhibition .content-section:first-of-type {
+            padding-top: 56px;
         }
 
         /* ── Breadcrumbs ── */
@@ -1128,6 +1177,256 @@
             color: var(--deep-blue);
         }
 
+        /* ── Artist page: dossier layout ── */
+        #page-artist .page-hero {
+            padding-top: 124px;
+            padding-bottom: 52px;
+        }
+        .artist-dossier-layout {
+            display: grid;
+            grid-template-columns: 240px 1fr;
+            gap: 40px;
+            align-items: start;
+        }
+        .artist-toc {
+            position: sticky;
+            top: 92px;
+            padding: 20px 18px;
+            background: #fff;
+            border: 1px solid var(--border-light);
+            border-radius: 2px;
+        }
+        .artist-toc h3 {
+            font-family: var(--sans);
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+            color: var(--gold-muted);
+            margin-bottom: 14px;
+        }
+        .artist-toc button {
+            display: block;
+            font-family: var(--sans);
+            font-size: 13px;
+            color: var(--text-muted);
+            text-align: left;
+            width: 100%;
+            background: none;
+            border: none;
+            cursor: pointer;
+            padding: 7px 0;
+            border-top: 1px solid rgba(0,0,0,0.04);
+            transition: color 0.2s ease;
+        }
+        .artist-toc button:hover { color: var(--deep-blue); }
+        .artist-toc button:first-of-type { border-top: none; }
+
+        .artist-intro-main {
+            background: #fff;
+            border: 1px solid var(--border-light);
+            padding: 32px;
+        }
+        .artist-intro-headline {
+            font-family: var(--serif);
+            font-size: clamp(24px, 3vw, 34px);
+            font-style: italic;
+            line-height: 1.35;
+            color: var(--deep-blue);
+            margin-bottom: 28px;
+        }
+        .artist-intro-grid {
+            display: grid;
+            grid-template-columns: 340px 1fr;
+            gap: 36px;
+            align-items: start;
+        }
+        .artist-intro-text p {
+            color: var(--text-muted);
+            margin-bottom: 16px;
+        }
+
+        .artist-life-geo-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 28px;
+        }
+        .artist-module {
+            background: rgba(255,255,255,0.75);
+            border: 1px solid var(--border-light);
+            padding: 28px;
+        }
+        .artist-module h3 {
+            margin-bottom: 20px;
+        }
+        .artist-map-placeholder {
+            margin-top: 20px;
+            aspect-ratio: 4/3;
+            background: var(--deep-blue);
+            border: 1px solid var(--border-dark);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+        }
+        .artist-map-placeholder i {
+            color: var(--gold-muted);
+            opacity: 0.5;
+            font-size: 34px;
+        }
+        .artist-map-placeholder span {
+            color: var(--text-light);
+            opacity: 0.55;
+            font-size: 11px;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        .artist-focus-grid {
+            display: grid;
+            grid-template-columns: 1.2fr 1fr;
+            gap: 28px;
+        }
+        .artist-focus-card {
+            background: #fff;
+            border: 1px solid var(--border-light);
+            padding: 22px;
+        }
+        .artist-focus-image {
+            aspect-ratio: var(--artwork-ratio);
+            background: var(--deep-blue);
+            border: 1px solid var(--border-dark);
+            margin-bottom: 16px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+        .artist-focus-image i {
+            color: var(--gold-muted);
+            opacity: 0.45;
+            font-size: 34px;
+        }
+        .artist-focus-image span {
+            font-size: 11px;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+            color: var(--text-light);
+            opacity: 0.45;
+            text-align: center;
+            padding: 0 14px;
+        }
+        .artist-focus-card h4 {
+            font-family: var(--serif);
+            font-size: 21px;
+            font-weight: 400;
+            color: var(--deep-blue);
+            margin-bottom: 10px;
+        }
+
+        .artist-method-grid {
+            display: grid;
+            grid-template-columns: repeat(5, minmax(0, 1fr));
+            gap: 14px;
+        }
+        .artist-method-item {
+            border: 1px solid var(--border-light);
+            background: #fff;
+            padding: 18px 16px;
+            min-height: 178px;
+        }
+        .artist-method-item h4 {
+            font-family: var(--serif);
+            font-size: 20px;
+            font-weight: 400;
+            margin-bottom: 10px;
+            color: var(--deep-blue);
+        }
+        .artist-method-item p {
+            margin-bottom: 0;
+            font-size: 14px;
+            line-height: 1.65;
+            color: var(--text-muted);
+        }
+
+        .artist-index-list {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 10px 24px;
+            max-width: 820px;
+        }
+        .artist-index-list span {
+            font-family: var(--serif);
+            font-size: 20px;
+            color: var(--deep-blue);
+            padding: 12px 0;
+            border-bottom: 1px solid var(--border-light);
+        }
+
+        .artist-diptych {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 22px;
+        }
+        .artist-diptych-card {
+            padding: 24px;
+            background: var(--museum-bg-cool);
+            border: 1px solid var(--border-light);
+        }
+        .artist-diptych-card h4 {
+            font-family: var(--serif);
+            font-size: 22px;
+            font-weight: 400;
+            color: var(--deep-blue);
+            margin-bottom: 12px;
+        }
+        .artist-diptych-card ul {
+            margin: 14px 0 0 18px;
+            color: var(--text-muted);
+            display: grid;
+            gap: 8px;
+            font-size: 14px;
+            line-height: 1.6;
+        }
+
+        .artist-archive-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 14px;
+        }
+        .artist-archive-item {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 16px 14px;
+            background: #fff;
+            border: 1px solid var(--border-light);
+        }
+        .artist-archive-item i {
+            color: var(--gold-muted);
+            font-size: 17px;
+            width: 18px;
+            text-align: center;
+        }
+        .artist-archive-item span {
+            font-family: var(--sans);
+            font-size: 14px;
+            color: var(--text-muted);
+        }
+
+        .artist-workshop-entry {
+            max-width: 820px;
+            display: grid;
+            gap: 18px;
+        }
+        .artist-etude-note {
+            max-width: 820px;
+            border-left: 2px solid var(--gold);
+            padding-left: 20px;
+        }
+
         /* ── Timeline ── */
         .timeline {
             position: relative;
@@ -1220,10 +1519,10 @@
             cursor: pointer;
             transition: transform 0.3s ease;
         }
-        .catalog-card:hover { transform: translateY(-4px); }
-        .catalog-card:hover .catalog-image { box-shadow: 0 16px 48px rgba(0,0,0,0.12); }
+        .catalog-card:hover { transform: translateY(-1px); }
+        .catalog-card:hover .catalog-image { box-shadow: 0 10px 24px rgba(0,0,0,0.08); }
         .catalog-image {
-            aspect-ratio: 4/5;
+            aspect-ratio: var(--artwork-ratio);
             background: var(--deep-blue);
             border-radius: 2px;
             margin-bottom: 14px;
@@ -1277,7 +1576,7 @@
             align-items: start;
         }
         .work-single-image {
-            aspect-ratio: 4/5;
+            aspect-ratio: var(--artwork-ratio);
             background: var(--deep-blue);
             border-radius: 2px;
             display: flex;
@@ -1292,6 +1591,8 @@
             inset: 20px;
             border: 1px solid var(--border-dark);
             display: flex;
+            flex-direction: column;
+            gap: 12px;
             align-items: center;
             justify-content: center;
         }
@@ -1299,6 +1600,15 @@
             font-size: 56px;
             color: var(--gold-muted);
             opacity: 0.3;
+        }
+        .work-single-image-inner span {
+            font-size: 11px;
+            color: var(--text-light);
+            opacity: 0.45;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+            text-align: center;
+            padding: 0 16px;
         }
         .work-single-info h1 {
             font-family: var(--serif);
@@ -1399,6 +1709,11 @@
             background: #fff;
             border: 1px solid var(--border-light);
             border-radius: 2px;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+        .info-card:hover {
+            border-color: rgba(18,28,57,0.22);
+            box-shadow: 0 8px 20px rgba(0,0,0,0.05);
         }
         .info-card-icon {
             width: 44px;


### PR DESCRIPTION
### Motivation
- Rework the artist page into a readable dossier with on-page navigation and clearer thematic sections to better present biography, routes and archive material.  
- Improve visual consistency of artwork frames and info cards by introducing a single aspect ratio and softer hover/interaction styles.  
- Make several copy and UI refinements (labels, buttons, removed redundant hero scroll) and add print-friendly rules for better offline/export rendering.

### Description
- Rebuilt the artist page (`#page-artist`) HTML into a dossier layout with a sticky table-of-contents (`aside.artist-toc`) and modular sections with IDs (e.g. `#artist-intro`, `#artist-life-geo`, `#artist-north`, `#artist-method`, `#artist-index`, `#artist-family`, `#artist-archive`, `#artist-workshop`, `#artist-etude`, `#artist-legacy`) and smooth-scroll buttons.  
- Updated many copy elements and micro content (hero subtitles, image captions like `Произведение из коллекции`, removed the hero-scroll element) and fixed markup around work cards/anchors to correct tag nesting.  
- Added CSS improvements: introduced `--artwork-ratio` root variable and applied it to `aspect-ratio` for hero frames, work/catalog/single images, adjusted hover transforms and shadows for `work-card`/`catalog-card`, added interactive transitions for `digital-block`/`info-card`, responsive grid adjustments for new artist components, and new styling for the dossier modules (timeline, archive items, method grid, diptych, etc.).  
- Added print media rules to hide navigation/canvas and ensure only the active page prints, plus small responsive tweaks and accessibility improvements for the artist TOC buttons.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c669ca63e48322a2e9403d9f225b3c)