### PR TITLE
Home page CSS: introduce grid-based home flow and tidy selectors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -458,126 +458,182 @@
         }
 
         /* ── Home compaction / editorial flow ── */
-        #page-home .home-intro-compact {
-padding-top: 46px;
-padding-bottom: 40px;
+#page-home .home-flow {
+    display: grid;
+    grid-template-columns: minmax(300px, 37%) minmax(0, 63%);
+    gap: 14px 18px;
+    align-items: start;
 }
+
+#page-home [data-component="home-teasers"] {
+    display: contents;
+}
+
+#page-home .home-grid-item {
+    padding-top: 34px;
+    padding-bottom: 34px;
+}
+
+#page-home .home-project { grid-column: 1; }
+#page-home .home-works-section { grid-column: 2; grid-row: 1 / span 2; }
+#page-home .home-artist-teaser { grid-column: 1; }
+#page-home .home-visit-teaser { grid-column: 1; }
+#page-home .home-digital-hub { grid-column: 2; }
+#page-home .home-full { grid-column: 1 / -1; }
+
+#page-home .home-intro-compact {
+    padding-top: 46px;
+    padding-bottom: 40px;
+}
+
 #page-home .home-compact {
     padding-top: 48px;
     padding-bottom: 48px;
 }
+
 #page-home .home-header-compact {
     margin-bottom: 22px;
 }
+
 #page-home .home-header-compact .section-title {
     font-size: clamp(22px, 2.8vw, 30px);
     margin-bottom: 8px;
 }
+
 #page-home .home-header-compact .section-lead {
     font-size: 14px;
     line-height: 1.55;
     max-width: 620px;
 }
+
 #page-home .home-works-section .works-grid {
     gap: 16px;
 }
-#page-home .home-works-section .work-card h4 { font-size: 15px; }
-#page-home .home-works-section .work-meta { font-size: 12px; }
+
+#page-home .home-works-section .work-card h4 {
+    font-size: 15px;
+}
+
+#page-home .home-works-section .work-meta {
+    font-size: 12px;
+}
+
 #page-home .home-artist-teaser .artist-grid {
     gap: 20px;
     grid-template-columns: 180px 1fr;
     align-items: center;
 }
+
 #page-home .home-artist-teaser .artist-portrait {
     aspect-ratio: 4/5;
 }
+
 #page-home .home-artist-teaser .artist-text h3 {
     font-size: 24px;
     font-style: normal;
     margin-bottom: 8px;
     color: var(--deep-blue);
 }
+
 #page-home .home-artist-teaser .artist-text p {
     max-width: 460px;
     margin-bottom: 10px;
     font-size: 14px;
     line-height: 1.6;
 }
+
 #page-home .home-artist-teaser .artist-buttons {
     margin-top: 10px;
 }
+
 #page-home .home-digital-hub .digital-blocks {
     gap: 12px;
     margin-bottom: 0;
 }
+
 #page-home .home-digital-hub .digital-block {
     padding: 16px 14px;
 }
+
 #page-home .home-digital-hub .digital-block-icon {
     margin-bottom: 10px;
     width: 36px;
     height: 36px;
 }
-#page-home .home-digital-hub .digital-block-icon i { font-size: 18px; }
+
+#page-home .home-digital-hub .digital-block-icon i {
+    font-size: 18px;
+}
+
 #page-home .home-digital-hub .digital-block h4 {
     font-size: 16px;
     margin-bottom: 6px;
 }
+
 #page-home .home-digital-hub .digital-block p {
     margin-bottom: 10px;
     line-height: 1.5;
     font-size: 13px;
 }
+
 #page-home .home-digital-hub .digital-block .btn {
     padding: 7px 11px;
     font-size: 11px;
     letter-spacing: 0.05em;
 }
+
 #page-home .home-visit-title {
     font-size: clamp(22px, 2.6vw, 30px);
     margin-bottom: 14px;
 }
+
 #page-home .home-visit-teaser .visit-grid {
     grid-template-columns: 1fr;
     gap: 0;
     max-width: 560px;
 }
+
 #page-home .home-visit-teaser .visit-info h3 {
     margin-bottom: 8px;
     font-size: 20px;
+    font-style: normal;
+    color: var(--deep-blue);
 }
-            font-style: normal;
-            color: var(--deep-blue);
-        }
-        #page-home .home-visit-teaser .visit-text {
-margin-bottom: 12px;
-font-size: 14px;
-line-height: 1.6;
+
+#page-home .home-visit-teaser .visit-text {
+    margin-bottom: 12px;
+    font-size: 14px;
+    line-height: 1.6;
 }
+
 #page-home .home-memory-quiet {
     padding-top: 30px;
     padding-bottom: 30px;
 }
+
 #page-home .home-memory-quiet .section-title {
     font-size: clamp(18px, 2vw, 24px);
     margin-bottom: 4px;
 }
+
 #page-home .home-memory-quiet .section-lead {
     font-size: 13px;
     line-height: 1.5;
     margin-bottom: 4px;
-        }
-        #page-home .home-memory-link {
-            padding: 8px 14px;
-            font-size: 11px;
-            border-color: var(--border-light);
-            color: var(--text-muted);
-        }
-        #page-home .home-memory-link:hover {
-            border-color: var(--deep-blue);
-            color: var(--deep-blue);
-            background: transparent;
-        }
+}
+
+#page-home .home-memory-link {
+    padding: 8px 14px;
+    font-size: 11px;
+    border-color: var(--border-light);
+    color: var(--text-muted);
+}
+
+#page-home .home-memory-link:hover {
+    border-color: var(--deep-blue);
+    color: var(--deep-blue);
+    background: transparent;
+}
 
         /* ── Artist section ── */
         .artist-grid {


### PR DESCRIPTION
### Motivation
- Replace ad-hoc spacing with a predictable editorial grid to improve home page composition and responsiveness.
- Make home teaser elements participate in the grid layout and centralize layout responsibilities for easier maintenance.
- Clean up and normalize selector blocks in `styles.css` for readability and consistency.

### Description
- Added a new `.home-flow` grid container and related grid column/row assignments for home components in `styles.css` to define a two-column editorial layout and gaps.
- Made `[data-component="home-teasers"]` use `display: contents` and introduced `.home-grid-item` padding plus `.home-full` to span full width.  Assigned explicit grid placement for `.home-project`, `.home-works-section`, `.home-artist-teaser`, `.home-visit-teaser`, and `.home-digital-hub`.
- Moved and reformatted many existing home-page rules (intro, compact, header, works, artist, digital hub, visit, memory link) without changing core sizes, and consolidated some visual properties like `.home-visit-teaser .visit-info h3` and `.home-memory-link:hover`.
- Adjusted whitespace/formatting and minor organizational tweaks in `styles.css` for improved maintainability.

### Testing
- Ran the frontend style linter and local CSS build for `styles.css`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca51c8bc8483229afe77df724c1b9a)