### PR TITLE
Enhance syncAbout to render school, themes, language sections and remove status notes

### DIFF
--- a/content-sync.js
+++ b/content-sync.js
@@ -252,6 +252,17 @@
       }
     }
 
+    setText('#artist-life-geo .subtitle', about?.school?.title);
+    if (Array.isArray(about?.school?.paragraphs)) {
+      const schoolTarget = document.querySelector('#artist-life-geo .artist-module:nth-child(2)');
+      if (schoolTarget) {
+        schoolTarget.innerHTML = [
+          '<h3 class="dark">Академическая школа</h3>',
+          ...about.school.paragraphs.map((text) => `<p class="dark">${text}</p>`)
+        ].join('');
+      }
+    }
+
     setText('#artist-north h2', about?.geography?.title);
     if (Array.isArray(about?.geography?.paragraphs)) {
       document.querySelectorAll('#artist-north .artist-focus-grid > div p.dark').forEach((p, idx) => {
@@ -261,10 +272,37 @@
 
     setText('#artist-index h2', about?.themes?.title);
     if (Array.isArray(about?.themes?.items)) {
+      const themeContainer = document.querySelector('#artist-index .artist-index-layout > div');
+      if (themeContainer) {
+        themeContainer.innerHTML = [
+          '<div class="artist-index-list">',
+          ...about.themes.items.map((item) => `<span>${item.title}</span>`),
+          '</div>'
+        ].join('');
+      }
+
+      const themeAside = document.querySelector('#artist-index .artist-index-layout .artist-module');
+      if (themeAside) {
+        themeAside.innerHTML = [
+          '<h3 class="dark">Темы и мотивы</h3>',
+          ...about.themes.items.map((item) => `<p class="dark"><strong>${item.title}.</strong> ${item.text || ''}</p>`)
+        ].join('');
+      }
+
       const chips = document.querySelectorAll('#artist-index .artist-index-list span');
       about.themes.items.slice(0, chips.length).forEach((item, idx) => {
         chips[idx].textContent = item.title;
       });
+    }
+
+    setText('#artist-method h2', about?.language?.title);
+    if (Array.isArray(about?.language?.paragraphs)) {
+      const languageIntro = document.querySelector('#artist-method .artist-method-intro');
+      if (languageIntro) {
+        languageIntro.innerHTML = about.language.paragraphs
+          .map((text) => `<p class="dark">${text}</p>`)
+          .join('');
+      }
     }
 
     setText('#artist-legacy h2', about?.legacy?.title);
@@ -273,6 +311,10 @@
         if (about.legacy.paragraphs[idx]) p.textContent = about.legacy.paragraphs[idx];
       });
     }
+
+    document.querySelectorAll('#page-artist .section-status-note').forEach((note) => {
+      note.remove();
+    });
   }
 
   function syncVisit(visit) {


### PR DESCRIPTION
### Motivation
- Extend the artist "about" page rendering to support additional structured content (school, themes, language) that is present in the source JSON.
- Improve layout by programmatically building theme lists and side content instead of relying on static DOM markup.
- Remove stale status notes from the artist page so they do not appear after content sync.

### Description
- Added rendering for `about.school` by setting a subtitle and populating the second `.artist-module` with an `Академическая школа` heading and its paragraphs using `innerHTML`.
- Reworked `about.themes` handling to build the `.artist-index-list` and the adjacent `.artist-module` aside with a `Темы и мотивы` heading and per-item paragraphs, while still preserving the existing chip population logic.
- Added rendering for `about.language` into `#artist-method .artist-method-intro` by joining paragraphs into HTML `<p class="dark">` elements and set the section heading via `setText`.
- Cleaned up any `.section-status-note` elements under `#page-artist` by removing them after sync.

### Testing
- Ran the existing automated test suite with `npm test`, which completed successfully.
- Verified that the updated `syncAbout` code paths are exercised by integration checks against the JSON fixture data used by the site build process, and these checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd9a5f8ec8322b6fc4173b3484b6a)