### PR TITLE
Restructure artist page and wire up content sync to new section IDs

### DIFF
--- a/content-sync.js
+++ b/content-sync.js
@@ -234,37 +234,67 @@
     setHTML('#page-artist .page-hero h1', about?.hero?.title ? about.hero.title.replace(/\s+(\S+)$/, ' <em>$1</em>') : null);
     setText('#page-artist .page-hero-subtitle', about?.hero?.subtitle);
 
-    setText('#artist-intro .artist-intro-headline', about?.intro?.headline);
+    setText('#artist-family .artist-intro-headline', about?.intro?.headline);
     if (Array.isArray(about?.intro?.paragraphs)) {
-      document.querySelectorAll('#artist-intro .artist-intro-text p').forEach((p, idx) => {
+      document.querySelectorAll('#artist-family .artist-intro-text p').forEach((p, idx) => {
         if (about.intro.paragraphs[idx]) p.textContent = about.intro.paragraphs[idx];
       });
     }
 
-    setText('#artist-life-geo h2', about?.biography?.title);
+    setText('#artist-family h2', about?.biography?.title);
     if (Array.isArray(about?.biography?.paragraphs)) {
-      const bioTarget = document.querySelector('#artist-life-geo .artist-module:first-child');
-      if (bioTarget) {
-        const ps = bioTarget.querySelectorAll('p.dark');
-        about.biography.paragraphs.slice(0, ps.length).forEach((text, idx) => {
-          ps[idx].textContent = text;
-        });
-      }
+      document.querySelectorAll('#artist-family .artist-family-body p.dark').forEach((p, idx) => {
+        if (about.biography.paragraphs[idx]) p.textContent = about.biography.paragraphs[idx];
+      });
     }
 
-    setText('#artist-north h2', about?.geography?.title);
+    setText('#artist-school h2', about?.school?.title);
+    if (Array.isArray(about?.school?.paragraphs)) {
+      document.querySelectorAll('#artist-school .content-narrow p.dark').forEach((p, idx) => {
+        if (about.school.paragraphs[idx]) p.textContent = about.school.paragraphs[idx];
+      });
+    }
+
+    setText('#artist-routes h2', about?.geography?.title);
     if (Array.isArray(about?.geography?.paragraphs)) {
-      document.querySelectorAll('#artist-north .artist-focus-grid > div p.dark').forEach((p, idx) => {
+      document.querySelectorAll('#artist-routes .artist-focus-grid > div p.dark').forEach((p, idx) => {
         if (about.geography.paragraphs[idx]) p.textContent = about.geography.paragraphs[idx];
       });
     }
 
     setText('#artist-index h2', about?.themes?.title);
     if (Array.isArray(about?.themes?.items)) {
+      const themeContainer = document.querySelector('#artist-index .artist-index-layout > div');
+      if (themeContainer) {
+        themeContainer.innerHTML = [
+          '<div class="artist-index-list">',
+          ...about.themes.items.map((item) => `<span>${item.title}</span>`),
+          '</div>'
+        ].join('');
+      }
+
+      const themeAside = document.querySelector('#artist-index .artist-index-layout .artist-module');
+      if (themeAside) {
+        themeAside.innerHTML = [
+          '<h3 class="dark">Темы и мотивы</h3>',
+          ...about.themes.items.map((item) => `<p class="dark"><strong>${item.title}.</strong> ${item.text || ''}</p>`)
+        ].join('');
+      }
+
       const chips = document.querySelectorAll('#artist-index .artist-index-list span');
       about.themes.items.slice(0, chips.length).forEach((item, idx) => {
         chips[idx].textContent = item.title;
       });
+    }
+
+    setText('#artist-method h2', about?.language?.title);
+    if (Array.isArray(about?.language?.paragraphs)) {
+      const languageIntro = document.querySelector('#artist-method .artist-method-intro');
+      if (languageIntro) {
+        languageIntro.innerHTML = about.language.paragraphs
+          .map((text) => `<p class="dark">${text}</p>`)
+          .join('');
+      }
     }
 
     setText('#artist-legacy h2', about?.legacy?.title);
@@ -273,6 +303,7 @@
         if (about.legacy.paragraphs[idx]) p.textContent = about.legacy.paragraphs[idx];
       });
     }
+
   }
 
   function syncVisit(visit) {

--- a/pages/artist.html
+++ b/pages/artist.html
@@ -17,111 +17,82 @@
             </div>
         </div>
 
-<section class="content-section bg-cool" id="artist-intro">
-    <div class="content-block reveal artist-dossier-layout">
-        <aside class="artist-toc" aria-label="Оглавление страницы художника">
-            <h3>Содержание</h3>
-            <button type="button" onclick="document.getElementById('artist-life-geo').scrollIntoView({behavior:'smooth', block:'start'});">Жизнь и география</button>
-            <button type="button" onclick="document.getElementById('artist-north').scrollIntoView({behavior:'smooth', block:'start'});">Русский Север</button>
-            <button type="button" onclick="document.getElementById('artist-method').scrollIntoView({behavior:'smooth', block:'start'});">Как он работал</button>
-            <button type="button" onclick="document.getElementById('artist-index').scrollIntoView({behavior:'smooth', block:'start'});">Круг мотивов</button>
-            <button type="button" onclick="document.getElementById('artist-family').scrollIntoView({behavior:'smooth', block:'start'});">Отец и сын</button>
-            <button type="button" onclick="document.getElementById('artist-archive').scrollIntoView({behavior:'smooth', block:'start'});">Архивный кабинет</button>
-            <button type="button" onclick="document.getElementById('artist-workshop').scrollIntoView({behavior:'smooth', block:'start'});">Мастерская</button>
-            <button type="button" onclick="document.getElementById('artist-etude').scrollIntoView({behavior:'smooth', block:'start'});">Незавершённое и этюдное</button>
-            <button type="button" onclick="document.getElementById('artist-legacy').scrollIntoView({behavior:'smooth', block:'start'});">Наследие</button>
-        </aside>
+        <section class="content-section bg-cool" id="artist-family">
+            <div class="content-block reveal artist-dossier-layout">
+                <aside class="artist-toc" aria-label="Оглавление страницы художника">
+                    <h3>Содержание</h3>
+                    <button type="button" onclick="document.getElementById('artist-family').scrollIntoView({behavior:'smooth', block:'start'});">Семья и истоки</button>
+                    <button type="button" onclick="document.getElementById('artist-school').scrollIntoView({behavior:'smooth', block:'start'});">Академическая школа</button>
+                    <button type="button" onclick="document.getElementById('artist-routes').scrollIntoView({behavior:'smooth', block:'start'});">Маршруты художника</button>
+                    <button type="button" onclick="document.getElementById('artist-method').scrollIntoView({behavior:'smooth', block:'start'});">Живописный язык и техника</button>
+                    <button type="button" onclick="document.getElementById('artist-index').scrollIntoView({behavior:'smooth', block:'start'});">Художественный мир</button>
+                    <button type="button" onclick="document.getElementById('artist-workshop').scrollIntoView({behavior:'smooth', block:'start'});">Мастерская</button>
+                    <button type="button" onclick="document.getElementById('artist-etude').scrollIntoView({behavior:'smooth', block:'start'});">Незавершённое и этюдное</button>
+                    <button type="button" onclick="document.getElementById('artist-legacy').scrollIntoView({behavior:'smooth', block:'start'});">Наследие</button>
+                </aside>
 
-        <div class="artist-intro-main">
-            <div class="artist-intro-headline">
-                Александр Львович Овчинников — художник, чьё творчество невозможно свести к одной теме, одному региону или одному устойчивому набору мотивов.
-            </div>
+                <div class="artist-intro-main">
+                    <h2 class="dark">Семья и истоки</h2>
+                    <div class="divider gold"></div>
+                    <div class="artist-intro-headline"></div>
 
-            <div class="artist-intro-grid">
-                <div class="artist-portrait">
-                    <div class="artist-portrait-placeholder">
-                        <i class="fa-solid fa-image-portrait"></i>
-                        <span>Архивный портрет</span>
+                    <div class="artist-intro-grid">
+                        <div class="artist-portrait">
+                            <div class="artist-portrait-placeholder">
+                                <i class="fa-solid fa-image-portrait"></i>
+                                <span>Портрет художника</span>
+                            </div>
+                            <div class="artist-portrait-frame"></div>
+                        </div>
+
+                        <div class="artist-intro-text">
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                        </div>
                     </div>
-                    <div class="artist-portrait-frame"></div>
-                </div>
 
-                <div class="artist-intro-text">
-                    <p>Александр Львович Овчинников — художник, чьё творчество невозможно свести к одной теме, одному региону или одному устойчивому набору мотивов. Русский Север занимает в его наследии важное, мощное и внутренне значимое место, но не исчерпывает его художественный мир. Правильнее говорить об Овчинникове как о художнике большого пространственного маршрута России, где Север, Волга, русский город, историческая память, южные впечатления, дом, предметный мир, звери и птицы, графика и этюдная живопись образуют единую систему образов.</p>
-                    <p>Эта широта особенно важна для понимания мастера сегодня. География Овчинникова — не просто биография поездок, а поле живописного и графического опыта, из которого складывался его собственный художественный язык.</p>
-                </div>
-            </div>
-        </div>
-    </div>
-</section>
-
-        <section class="content-section bg-light" id="artist-life-geo">
-            <div class="content-block reveal">
-                <h2 class="dark">Жизнь и география</h2>
-                <div class="subtitle dark">Биография и академическая школа</div>
-                <div class="divider gold"></div>
-                <div class="artist-life-geo-grid" style="margin-top: 40px;">
-                    <article class="artist-module">
-                        <h3 class="dark">Путь художника</h3>
-                        <p class="dark">Александр Овчинников родился 26 апреля 1956 года в Ленинграде в семье художника. Ленинград важен для него не только биографически: это город академической школы, строгой профессиональной культуры и высокой требовательности к живописи. В 1985 году он окончил Институт живописи, скульптуры и архитектуры имени И. Е. Репина, а в 1990 году был принят в Санкт-Петербургское отделение Союза художников.</p>
-                        <p class="dark">Петербургская академическая школа дала ему не просто профессиональный статус, а внутренний каркас художественного мышления: внимание к рисунку, к тону, к пространственной дисциплине и к материальности поверхности. Но эта школа не превратилась у него в закрытую систему. Напротив, именно она позволила ему одинаково уверенно работать в эпическом полотне, камерном городском этюде, интерьере и линогравюре.</p>
-                        <div class="artist-fact-box">
-                            <strong>Фактографическая врезка</strong>
-                            <p>Родился — 26 апреля 1956 года, Ленинград</p>
-                            <p>Академическая школа — Институт имени И. Е. Репина, окончание в 1985 году</p>
-                            <p>Союз художников — С 1990 года — Санкт-Петербургское отделение Союза художников</p>
-                            <p>Ключевые маршруты — Русский Север, Волга, Нижний Новгород, Городец, Балахна, Ветлуга, Васильсурск, Псков, Великий Новгород, Алупка</p>
-                        </div>
-                    </article>
-                    <aside class="artist-module">
-                        <h3 class="dark">Хронология маршрутов</h3>
-                        <div class="timeline artist-compact-timeline">
-                            <div class="timeline-item">
-                                <div class="year">Конец 1970-х — середина 1980-х</div>
-                                <h4>Маршруты</h4>
-                                <p>Крым, Москва, Владимир, Суздаль, Нижний Новгород, Казань, Чебоксары, Ядрин, Цивильск.</p>
-                            </div>
-                            <div class="timeline-item">
-                                <div class="year">1970-е — 1980-е</div>
-                                <h4>Северный и деревенский опыт</h4>
-                                <p>Северный и деревенский опыт: Архангельск, Карпогоры, Веркола, Мезень, Пинега, Вологодчина, Вытегра.</p>
-                            </div>
-                            <div class="timeline-item">
-                                <div class="year">1990-е</div>
-                                <h4>Историко-городской пласт</h4>
-                                <p>Историко-городской пласт: Псков, Великие Луки, Великий Новгород, Ярославль, Кострома.</p>
-                            </div>
-                            <div class="timeline-item">
-                                <div class="year">2000-е — 2010-е</div>
-                                <h4>Зрелые возвраты</h4>
-                                <p>Зрелые возвраты: Городец, Балахна, Ветлуга, Васильсурск, Тамбов, Кемь — Гридино.</p>
-                            </div>
-                        </div>
-                    </aside>
+                    <div class="artist-family-body" style="margin-top: 28px;">
+                        <p class="dark"></p>
+                        <p class="dark"></p>
+                        <p class="dark"></p>
+                    </div>
                 </div>
             </div>
         </section>
 
-        <section class="content-section bg-cool" id="artist-north">
+        <section class="content-section bg-light" id="artist-school">
             <div class="content-block reveal">
-                <h2 class="dark">География творчества</h2>
-                <div class="subtitle dark">Большой маршрут России</div>
+                <h2 class="dark">Академическая школа</h2>
+                <div class="divider gold"></div>
+                <div class="content-narrow" style="margin-top: 32px;">
+                    <p class="dark"></p>
+                    <p class="dark"></p>
+                    <p class="dark"></p>
+                </div>
+                <div class="artist-fact-box" style="margin-top: 24px;">
+                    <strong>Ключевые вехи</strong>
+                </div>
+            </div>
+        </section>
+
+        <section class="content-section bg-cool" id="artist-routes">
+            <div class="content-block reveal">
+                <h2 class="dark">Маршруты художника</h2>
                 <div class="divider gold"></div>
                 <div class="artist-focus-grid" style="margin-top: 36px;">
                     <div>
-                        <p class="dark">География творчества Овчинникова — это большой маршрут, а не одна тема. Уже в 1979–1986 годах в него входят Крым, Москва, Владимир, Суздаль, Нижний Новгород, Казань, Чебоксары, Ядрин и Цивильск. Северный маршрут, начавшийся ещё в 1970-е годы, проходит через Архангельск, Карпогоры, Верколу, Мезень, Пинегу, Вологодчину и Вытегру. В 1990-е усиливается историко-городской пласт — Псков, Великие Луки, Великий Новгород, Ярославль, Кострома. В 2000-е и 2010-е художник возвращается к Городцу, Балахне, Ветлуге, Васильсурску, Тамбову и позднему беломорскому маршруту Кемь — Гридино.</p>
-                        <p class="dark">Важно, что значительная часть этих поездок была связана с работой с натуры. Поэтому Север, Волга, старый русский город и Крым следует понимать не как фон биографии, а как реальные поля наблюдения и этюдной работы, из которых вырастали большие композиции и образы памяти.</p>
+                        <p class="dark"></p>
+                        <p class="dark"></p>
+                        <p class="dark"></p>
                     </div>
                     <aside class="artist-focus-card">
                         <div class="artist-focus-image">
                             <i class="fa-solid fa-mountain-sun"></i>
-                            <span>Архивный модуль · северный лист и этюд</span>
+                            <span>Северный лист и этюд</span>
                         </div>
-                        <h4>Опорный мотив</h4>
-                        <p>Деревянное зодчество, широкая линия горизонта и свет «долгого дня» образуют устойчивый визуальный словарь северного цикла.</p>
                         <div class="artist-fact-box compact">
-                            <strong>Ключевой принцип</strong>
-                            <p>Этюд сохраняет самостоятельную художественную ценность и не сводится к подготовительному материалу.</p>
+                            <strong>Важно для понимания</strong>
                         </div>
                     </aside>
                 </div>
@@ -130,107 +101,25 @@
 
         <section class="content-section bg-light" id="artist-method">
             <div class="content-block reveal">
-                <h2 class="dark">Как он работал</h2>
-                <div class="subtitle dark">Пластический метод: от полевого наблюдения к собранной композиции</div>
+                <h2 class="dark">Живописный язык и техника</h2>
                 <div class="divider gold"></div>
                 <div class="artist-method-intro" style="margin-top: 32px;">
-                    <p class="dark"><strong>Лид раздела.</strong> Метод Овчинникова основан на медленном цикле: натурное впечатление — этюд — длительная работа в мастерской — итоговая картина.</p>
-                    <p class="dark">Такой процесс позволял сохранять достоверность наблюдения и одновременно выстраивать историческую глубину образа. Мастерская в этом контуре служила не местом «исправления натуры», а лабораторией композиции, ритма и цветовой среды.</p>
-                </div>
-                <div class="artist-method-grid" style="margin-top: 24px;">
-                    <article class="artist-method-item">
-                        <h4>Натура</h4>
-                        <p>Экспедиция и работа на месте задавали первичный масштаб и световой строй будущей композиции.</p>
-                    </article>
-                    <article class="artist-method-item">
-                        <h4>Этюд</h4>
-                        <p>Краткая форма фиксировала состояние пространства и часто воспринималась как завершённое произведение.</p>
-                    </article>
-                    <article class="artist-method-item">
-                        <h4>Сборка</h4>
-                        <p>В мастерской материал сопоставлялся, уточнялся, проходил через композиционный отбор.</p>
-                    </article>
-                    <article class="artist-method-item">
-                        <h4>Большое полотно</h4>
-                        <p>Итоговая работа сохраняла «дыхание натуры», но расширялась до эпического регистра.</p>
-                    </article>
-                </div>
-                <div class="artist-inline-archive">
-                    <i class="fa-solid fa-box-archive"></i>
-                    <p>Архивный модуль: в разделе планируется публикация последовательностей «этюд → рабочее состояние → итоговая картина».</p>
+                    <p class="dark"></p>
+                    <p class="dark"></p>
+                    <p class="dark"></p>
                 </div>
             </div>
         </section>
 
         <section class="content-section bg-cool" id="artist-index">
             <div class="content-block reveal">
-                <h2 class="dark">Круг мотивов</h2>
-                <div class="subtitle dark">Тематический диапазон, внутри которого работает единый художественный язык</div>
+                <h2 class="dark">Художественный мир</h2>
                 <div class="divider gold"></div>
                 <div class="artist-index-layout" style="margin-top: 32px;">
                     <div>
-                        <p class="dark"><strong>Лид раздела.</strong> Наследие Овчинникова разворачивается не вокруг одного жанра, а вокруг нескольких устойчивых направлений, связанных общей оптикой пространства памяти.</p>
-                        <p class="dark">Северный пейзаж, русский город, исторический мотив, интерьер и предметный мир формируют цельный корпус. Даже в дальних маршрутах и графике художник сохраняет ту же внимательность к структуре места и культурному времени.</p>
-                        <div class="artist-index-list">
-                            <span>Русский Север</span>
-                            <span>Русский город</span>
-                            <span>Историческая тема</span>
-                            <span>Интерьер и мастерская</span>
-                            <span>Предметный мир</span>
-                            <span>Волга и Юг</span>
-                            <span>Графика</span>
-                            <span>Натурный этюд</span>
-                        </div>
+                        <div class="artist-index-list"></div>
                     </div>
-                    <aside class="artist-module">
-                        <h3 class="dark">Врезка: как читать раздел</h3>
-                        <p class="dark">При просмотре работ полезно сопоставлять мотив и метод: где этюд сохраняет автономию, где архитектура становится носителем памяти, а где композиция строится вокруг камерного предметного центра.</p>
-                        <p class="dark">Этот индекс задаёт навигацию для будущего каталога и архивных подборок.</p>
-                    </aside>
-                </div>
-            </div>
-        </section>
-
-        <section class="content-section bg-light" id="artist-family">
-            <div class="content-block reveal">
-                <h2 class="dark">Художественная среда дома</h2>
-                <div class="subtitle dark">Семья как среда формирования художника</div>
-                <div class="divider gold"></div>
-                <div class="artist-diptych" style="margin-top: 36px;">
-                    <article class="artist-diptych-card">
-                        <h4>Семейная линия</h4>
-                        <p>Семейная линия в судьбе Овчинникова имеет принципиальное значение. Отец, Лев Авксентьевич Овчинников, был живописцем, и именно через эту фигуру Александр с детства вошёл в мир художественного труда, в атмосферу мастерской и в ощущение того, что художник живёт внутри культурной преемственности. Ранний рисунок Льва Овчинникова, изображающий маленького Александра за рисованием, почти документально фиксирует начало этой судьбы.</p>
-                        <ul>
-                            <li>Через семью Овчинников получает не только профессиональную ориентацию, но и особое отношение к натуре: внимание к миру, к предмету, к дому, к улице, к человеку, к зверю и к дереву.</li>
-                            <li>Отцовская среда формирует в нём не копирование старшего поколения, а серьёзность взгляда и доверие к реальности.</li>
-                        </ul>
-                    </article>
-                    <article class="artist-diptych-card">
-                        <h4>Среда формирования</h4>
-                        <p>Через семью Овчинников получает не только профессиональную ориентацию, но и особое отношение к натуре: внимание к миру, к предмету, к дому, к улице, к человеку, к зверю и к дереву. Отцовская среда формирует в нём не копирование старшего поколения, а серьёзность взгляда и доверие к реальности.</p>
-                        <ul>
-                            <li>Семейная линия в судьбе Овчинникова имеет принципиальное значение.</li>
-                            <li>Ранний рисунок Льва Овчинникова, изображающий маленького Александра за рисованием, почти документально фиксирует начало этой судьбы.</li>
-                        </ul>
-                    </article>
-                </div>
-                <p class="dark" style="margin-top: 28px;">Через семью Овчинников получает не только профессиональную ориентацию, но и особое отношение к натуре: внимание к миру, к предмету, к дому, к улице, к человеку, к зверю и к дереву. Отцовская среда формирует в нём не копирование старшего поколения, а серьёзность взгляда и доверие к реальности.</p>
-            </div>
-        </section>
-
-        <section class="content-section bg-cool" id="artist-archive">
-            <div class="content-block reveal">
-                <h2 class="dark">Архивный кабинет</h2>
-                <p class="section-status-note">Раздел находится в редакционной доработке: структура фонда уже собрана, публикация материалов будет расширяться поэтапно.</p>
-                <div class="subtitle dark">Рабочий архив художника</div>
-                <div class="divider gold"></div>
-                <div class="artist-archive-grid" style="margin-top: 32px;">
-                    <div class="artist-archive-item"><i class="fa-solid fa-file-lines"></i><span>Документы</span></div>
-                    <div class="artist-archive-item"><i class="fa-solid fa-camera"></i><span>Фотографии</span></div>
-                    <div class="artist-archive-item"><i class="fa-solid fa-book"></i><span>Записные книжки</span></div>
-                    <div class="artist-archive-item"><i class="fa-solid fa-envelope-open-text"></i><span>Письма</span></div>
-                    <div class="artist-archive-item"><i class="fa-solid fa-layer-group"></i><span>Листы и эскизы</span></div>
-                    <div class="artist-archive-item"><i class="fa-solid fa-box-archive"></i><span>Рабочие материалы</span></div>
+                    <aside class="artist-module"></aside>
                 </div>
             </div>
         </section>
@@ -238,7 +127,6 @@
         <section class="content-section bg-light" id="artist-workshop">
             <div class="content-block reveal">
                 <h2 class="dark">Мастерская как автопортрет</h2>
-                <p class="section-status-note">Раздел подготовлен как переход к цифровой реконструкции и будет дополнен архивными комментариями.</p>
                 <div class="divider gold"></div>
                 <div class="artist-workshop-entry">
                     <p class="dark">Мастерская художника сохранена как мемориальное пространство. В её устройстве читается биография метода: натурные этюды, рабочие состояния, инструменты и материалы складываются в автопортрет художника, созданный не словами, а вещами и следами работы.</p>
@@ -250,7 +138,6 @@
         <section class="content-section bg-cool" id="artist-etude">
             <div class="content-block reveal">
                 <h2 class="dark">Незавершённое и этюдное</h2>
-                <p class="section-status-note">К разделу добавляются сопоставления этюдов и завершённых полотен.</p>
                 <div class="subtitle dark">Рабочие состояния как часть наследия</div>
                 <div class="divider gold"></div>
                 <div class="artist-etude-note">
@@ -263,11 +150,11 @@
         <section class="content-section bg-light" id="artist-legacy">
             <div class="content-block reveal">
                 <h2 class="dark">Наследие</h2>
-                <p class="section-status-note">Финальный блок фиксирует направления дальнейшей исследовательской и архивной работы.</p>
                 <div class="divider gold"></div>
                 <div class="content-narrow" style="margin-top: 32px;">
-                    <p>Наследие Овчинникова важно видеть не как один северный цикл и не как набор отдельных произведений, а как цельную художественную систему. Северный дом, волжская даль, старая улица, Крым, предмет народного быта, зверь и птица, интерьер с окном и исторический мотив складываются у него в художественный образ России как пространства памяти.</p>
-                    <p>Александр Львович Овчинников — художник не одного региона и не одной темы, а большого пространственного маршрута России. Русский Север — важная часть этого мира, но не его предел. Только такая рамка — Север, Волга, русский город, история, интерьер, предметная культура, южные впечатления и графика — позволяет увидеть масштаб художника по-настоящему.</p>
+                    <p></p>
+                    <p></p>
+                    <p></p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
### Motivation
- Reorganize the artist dossier into clearer thematic sections (family, school, routes, method, index, etc.) and replace large blocks of static copy with content placeholders for CMS-driven population.
- Update the content synchronization code so the `/about` JSON can populate the new DOM structure and dynamic lists (themes, language, biography, school, geography).

### Description
- Reworked `pages/artist.html` to rename and restructure sections (e.g. `artist-intro` → `artist-family`, `artist-life-geo` → `artist-school`, `artist-north` → `artist-routes`) and replaced hardcoded text with placeholder elements and simplified modules for dynamic population.  
- Adjusted layout and table-of-contents buttons to point at the new section IDs and removed duplicated static content, adding semantic blocks such as `.artist-family-body`, `.artist-index-list`, and `.artist-method-intro` for injected content.  
- Updated `content-sync.js` to use the new selectors and to map `about` data into the page, including rendering `about.intro`, `about.biography`, `about.school`, `about.geography`, `about.themes` (building both a list and an aside block), and `about.language` paragraphs.  
- Improved HTML injection where needed (e.g. building theme list markup, rendering paragraphs arrays) and replaced several `querySelectorAll` targets to match the new IDs and class names.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd9a5f8ec8322b6fc4173b3484b6a)