### PR TITLE
Clean up empty artist page scaffolds and tighten vertical rhythm

### DIFF
--- a/pages/artist.html
+++ b/pages/artist.html
@@ -36,14 +36,7 @@
                     <div class="divider gold"></div>
                     <div class="artist-intro-headline"></div>
 
-                    <div class="artist-intro-grid">
-                        <div class="artist-portrait">
-                            <div class="artist-portrait-placeholder">
-                                <i class="fa-solid fa-image-portrait"></i>
-                            </div>
-                            <div class="artist-portrait-frame"></div>
-                        </div>
-
+                    <div class="artist-intro-grid artist-intro-grid--text-only">
                         <div class="artist-intro-text">
                             <p></p>
                             <p></p>
@@ -69,9 +62,6 @@
                     <p class="dark"></p>
                     <p class="dark"></p>
                 </div>
-                <div class="artist-fact-box" style="margin-top: 24px;">
-                    <span style="font-family: var(--sans); font-size: 12px; letter-spacing: 0.08em; color: var(--text-muted); text-transform: uppercase;">Ключевые вехи</span>
-                </div>
             </div>
         </section>
 
@@ -85,15 +75,6 @@
                         <p class="dark"></p>
                         <p class="dark"></p>
                     </div>
-                    <aside class="artist-focus-card">
-                        <div class="artist-focus-image">
-                            <i class="fa-solid fa-mountain-sun"></i>
-                            <span>Северный лист и этюд</span>
-                        </div>
-                        <div class="artist-fact-box compact">
-                            <span style="font-family: var(--sans); font-size: 12px; letter-spacing: 0.08em; color: var(--text-muted); text-transform: uppercase;">Важно для понимания</span>
-                        </div>
-                    </aside>
                 </div>
             </div>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -1390,6 +1390,9 @@
             padding-top: 124px;
             padding-bottom: 52px;
         }
+        #page-artist .content-section {
+            padding: 64px 48px;
+        }
         .artist-dossier-layout {
             display: grid;
             grid-template-columns: minmax(0, 240px) 1fr;
@@ -1449,6 +1452,10 @@
             gap: 36px;
             align-items: start;
         }
+        .artist-intro-grid--text-only {
+            grid-template-columns: 1fr;
+            gap: 0;
+        }
         .artist-intro-text p {
             color: var(--text-muted);
             margin-bottom: 16px;
@@ -1493,8 +1500,9 @@
 
         .artist-focus-grid {
             display: grid;
-            grid-template-columns: 1.2fr 1fr;
-            gap: 28px;
+            grid-template-columns: 1fr;
+            gap: 0;
+            max-width: 860px;
         }
         .artist-focus-card {
             background: #fff;
@@ -2434,6 +2442,7 @@
             .page-hero { padding: 120px 24px 56px; }
             .breadcrumbs { padding: 16px 24px; }
             .content-section { padding: 56px 24px; }
+            #page-artist .content-section { padding: 48px 24px; }
             .content-two-col { grid-template-columns: 1fr; gap: 40px; }
             .catalog-grid { grid-template-columns: 1fr 1fr; }
             .work-single-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
### Motivation
- Remove empty placeholder scaffolds on the /artist page that create large visual gaps while the real content comes from `09_SOURCE_JSON/pages/about.json`.
- Make the first blocks text-first and remove decorative empty cards so the reading flow is continuous and denser.
- Slightly reduce vertical spacing for artist sections without breaking the existing responsive behavior.

### Description
- Removed the empty portrait/media placeholder and related markup in the "Семья и истоки" section and switched the intro grid to a text-only variant (`artist-intro-grid--text-only`).
- Removed the unfilled "Ключевые вехи" fact box from the "Академическая школа" section to avoid an empty white stripe under the text.
- Removed the placeholder right-side card ("Северный лист и этюд" / "Важно для понимания") from the "Маршруты художника" section so it behaves as a single-column text block.
- Updated `styles.css` to reduce vertical padding for `#page-artist .content-section`, add the `.artist-intro-grid--text-only` mode, switch `.artist-focus-grid` to a single-column flow by default, and tighten mobile padding for artist sections.
- Did not change any JSON source files; runtime text continues to be supplied from `09_SOURCE_JSON/pages/about.json` via existing `content-sync.js` bindings.

### Testing
- Ran `git diff -- pages/artist.html styles.css` to confirm the intended changes are present and it completed successfully.
- Ran `rg -n "Ключевые вехи|Северный лист и этюд|Важно для понимания|artist-portrait-placeholder" pages/artist.html styles.css` to verify removed scaffolds and it returned expected results.
- Committed the changes with a repository commit which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce3b4bf7b08322b106f3f4c58d4544)