### PR TITLE
Rebuild /artist "Художественный мир" as JSON-driven theme card grid

### DIFF
--- a/content-sync.js
+++ b/content-sync.js
@@ -352,25 +352,17 @@
 
     setText('#artist-index h2', about?.themes?.title);
     if (Array.isArray(about?.themes?.items)) {
-      const themeContainer = document.querySelector('#artist-index .artist-index-list');
+      const themeContainer = document.querySelector('#artist-index .artist-theme-grid');
       if (themeContainer) {
         themeContainer.innerHTML = about.themes.items
-          .map((item) => `<span>${item.title}</span>`)
+          .map((item) => `
+            <article class="artist-theme-card">
+              <h3>${item.title || ''}</h3>
+              <p class="dark">${item.text || ''}</p>
+            </article>
+          `)
           .join('');
       }
-
-      const themeAside = document.querySelector('#artist-index .artist-module');
-      if (themeAside) {
-        themeAside.innerHTML = [
-          '<h3 class="dark">Темы и мотивы</h3>',
-          ...about.themes.items.map((item) => `<p class="dark"><strong>${item.title}.</strong> ${item.text || ''}</p>`)
-        ].join('');
-      }
-
-      const chips = document.querySelectorAll('#artist-index .artist-index-list span');
-      about.themes.items.slice(0, chips.length).forEach((item, idx) => {
-        chips[idx].textContent = item.title;
-      });
     }
 
     setText('#artist-method h2', about?.language?.title);

--- a/pages/artist.html
+++ b/pages/artist.html
@@ -114,12 +114,9 @@
             <div class="content-block reveal">
                 <h2 class="dark">Художественный мир</h2>
                 <div class="divider gold"></div>
-                <div class="artist-index-layout artist-index-layout--stacked" style="margin-top: 32px;">
-                    <div class="artist-index-summary">
-                        <p class="dark artist-index-lead">Этот раздел собирает ключевые мотивы в цельную картину художественного мира.</p>
-                        <div class="artist-index-list"></div>
-                    </div>
-                    <aside class="artist-module artist-index-detail"></aside>
+                <div class="artist-index-layout" style="margin-top: 32px;">
+                    <p class="dark artist-index-lead">Этот раздел собирает ключевые мотивы в цельную картину художественного мира.</p>
+                    <div class="artist-theme-grid"></div>
                 </div>
             </div>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -1176,7 +1176,7 @@
             .footer-nav { justify-self: start; }
             .geo-inner { flex-direction: column; text-align: center; }
             .artist-intro-main { padding: 22px; }
-            .artist-index-list { grid-template-columns: 1fr; }
+            .artist-theme-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
             #page-home .home-intro-compact,
 #page-home .home-compact { padding-top: 42px; padding-bottom: 42px; }
 #page-home .home-memory-quiet { padding-top: 28px; padding-bottom: 28px; }
@@ -1189,6 +1189,7 @@
             .hero-buttons .btn { width: 100%; justify-content: center; }
             .artist-method-grid { grid-template-columns: 1fr; }
             .artist-archive-grid { grid-template-columns: 1fr; }
+            .artist-theme-grid { grid-template-columns: 1fr; }
         }
 
         /* ── Page transitions ── */
@@ -1559,19 +1560,34 @@
             color: var(--text-muted);
         }
 
-        .artist-index-list {
+        .artist-theme-grid {
             display: grid;
-            grid-template-columns: repeat(2, minmax(260px, 1fr));
-            gap: 10px 24px;
-            max-width: none;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 16px;
             width: 100%;
         }
-        .artist-index-list span {
+        .artist-theme-card {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            padding: 20px 18px;
+            background: #fff;
+            border: 1px solid var(--border-light);
+        }
+        .artist-theme-card h3 {
+            margin: 0;
             font-family: var(--serif);
-            font-size: 20px;
+            font-size: 21px;
+            font-weight: 400;
             color: var(--deep-blue);
-            padding: 12px 0;
-            border-bottom: 1px solid var(--border-light);
+            line-height: 1.3;
+        }
+        .artist-theme-card p {
+            margin: 0;
+            font-family: var(--sans);
+            font-size: 14px;
+            line-height: 1.7;
+            color: var(--text-muted);
         }
 
         .artist-diptych {
@@ -1682,26 +1698,14 @@
             line-height: 1.65;
             color: var(--text-muted);
         }
-        .artist-index-flow {
+        .artist-index-layout {
             display: grid;
-            gap: 18px;
-        }
-        .artist-index-intro {
-            margin-bottom: 0;
-            max-width: 860px;
-        }
-        .artist-index-layout--stacked {
-            grid-template-columns: 1fr;
-        }
-        .artist-index-summary {
-            max-width: 100%;
+            gap: 20px;
+            width: 100%;
         }
         .artist-index-lead {
-            max-width: 860px;
-            margin-bottom: 18px;
-        }
-        .artist-index-detail {
-            max-width: 860px;
+            max-width: 780px;
+            margin-bottom: 0;
         }
         .section-status-note {
             margin: 8px 0 0;
@@ -1740,6 +1744,9 @@
             .artist-archive-grid {
                 grid-template-columns: repeat(2, 1fr);
             }
+            .artist-theme-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
         }
         @media (max-width: 480px) {
             .artist-method-grid {
@@ -1750,6 +1757,9 @@
             }
             .artist-intro-headline {
                 font-size: clamp(16px, 5vw, 20px);
+            }
+            .artist-theme-grid {
+                grid-template-columns: 1fr;
             }
         }
 


### PR DESCRIPTION
### Motivation
- Упрощение и выравнивание секции «Художественный мир» для устранения пустот и хаоса компоновки, вызванного разделением на список тем и отдельную длинную расшифровку.
- Сделать верстку полностью управляемой из JSON-источника `09_SOURCE_JSON/pages/about.json` -> `themes.items` и обеспечить предсказуемое поведение на всех разрешениях.

### Description
- Заменил композицию в `pages/artist.html`: убрал отдельный список и aside-расшифровку и сделал поток `h2` → короткий лид → единый контейнер `.artist-theme-grid`.
- Обновил `syncAbout(about)` в `content-sync.js` так, чтобы он рендерил карточки из `about.themes.items`, создавая для каждого элемента `.artist-theme-card` с `h3` = `item.title` и `p` = `item.text` (текст остаётся в JSON, не хардкодится в HTML).
- Добавил/CSS-правила в `styles.css` для карточной сетки: desktop — 3 колонки, tablet — 2 колонки, mobile — 1 колонка; карточки без фиксированных больших высот; заголовки — `serif`, тексты — `sans`; ограничил возможность horizontal overflow.
- Файлы изменены: `pages/artist.html`, `content-sync.js`, `styles.css` (источник текста `09_SOURCE_JSON/pages/about.json` не тронут).

### Testing
- Проверка синтаксиса JS: `node --check content-sync.js` — успешно.
- Поиск устаревших классов/шаблонов: `rg -n "artist-index-list|artist-index-detail|artist-index-summary|artist-index-layout--stacked" pages/artist.html content-sync.js styles.css` — старые классы в изменённых файлах удалены (нет результатов).
- Локальная вёрстка и ручная проверка (макет): просмотр изменённых секций в браузере подразумевается как следующая проверка; автоматических визуальных тестов в репозитории не запускал.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e76c8a748322b0f473e9bc6ffbcd)