### PR TITLE
Revamp artist route map module, projection, legend, styles and safe layer loading

### DIFF
--- a/artist-route-map.js
+++ b/artist-route-map.js
@@ -7,13 +7,13 @@
   const RIVERS_URL = 'https://cdn.jsdelivr.net/gh/nvkelso/natural-earth-vector@master/geojson/ne_110m_rivers_lake_centerlines.geojson';
 
   const PERIOD_COLORS = {
-    base: '#8C6239',
-    historical_city: '#A27449',
-    early_wide: '#BE8A55',
-    volga: '#C69764',
-    mature_return: '#AD7C4B',
-    north: '#5E7D90',
-    south: '#8F5B62'
+    base: '#5D9ECF',
+    historical_city: '#4D96C5',
+    early_wide: '#C5843F',
+    volga: '#C8A029',
+    mature_return: '#BB8B2A',
+    north: '#3D8DBA',
+    south: '#C46A31'
   };
 
   function loadScript(src) {
@@ -42,41 +42,74 @@
     return null;
   }
 
+  function safeFetchJson(path) {
+    return fetchJson(path).catch((error) => {
+      console.warn(`Optional layer failed: ${path}`, error);
+      return null;
+    });
+  }
+
+  function setModuleStatus(message) {
+    const status = document.querySelector('#page-artist #artist-routes #mstatus');
+    if (status) status.textContent = message;
+  }
+
+  function getRussiaFeature(countriesFeatureCollection) {
+    return countriesFeatureCollection?.features?.find((feature) => Number(feature?.id) === 643) || null;
+  }
+
+  function buildLegend(host, route) {
+    if (!host) return;
+    const labels = route?.map?.periodLabels || {};
+    const keys = Object.keys(labels).filter((key) => PERIOD_COLORS[key]);
+    host.innerHTML = keys.map((key) => `
+      <div class="artist-route-map-legend-item">
+        <span class="dot" style="background:${PERIOD_COLORS[key]}"></span>
+        <span>${labels[key]}</span>
+      </div>
+    `).join('');
+  }
+
   function renderMap(route, worldAtlas, lakesJson, riversJson) {
-    const host = document.querySelector('#artist-routes .artist-route-map-card');
-    if (!host || !route || !Array.isArray(route.points)) return;
+    const host = document.querySelector('#page-artist #artist-routes .artist-route-map-module');
+    if (!host || !route || !Array.isArray(route.points) || route.points.length === 0) return;
 
-    const mapShell = host.querySelector('.artist-route-map-shell');
-    const canvas = host.querySelector('.artist-route-map-canvas');
-    const tooltip = host.querySelector('.artist-route-map-tooltip');
-    const chips = host.querySelector('.artist-route-map-chips');
-    const detailTitle = host.querySelector('.artist-route-map-detail h4');
-    const detailText = host.querySelector('.artist-route-map-detail-text');
-    const detailMeta = host.querySelector('.artist-route-map-detail-meta');
+    const mapShell = host.querySelector('#map-container');
+    const canvas = host.querySelector('#msvg');
+    const tooltip = host.querySelector('#mtip');
+    const status = host.querySelector('#mstatus');
+    const legend = host.querySelector('#mleg');
+    const detailWrap = document.querySelector('#page-artist #artist-routes .artist-route-map-detail');
+    const detailTitle = detailWrap?.querySelector('h4');
+    const detailText = detailWrap?.querySelector('.artist-route-map-detail-text');
+    const detailMeta = detailWrap?.querySelector('.artist-route-map-detail-meta');
 
-    if (!mapShell || !canvas || !tooltip || !chips || !detailTitle || !detailText || !detailMeta) return;
+    if (!mapShell || !canvas || !tooltip || !status || !legend || !detailTitle || !detailText || !detailMeta) return;
 
     const d3 = window.d3;
     const topojson = window.topojson;
+    const width = 1320;
+    const height = 720;
 
     canvas.innerHTML = '';
+    buildLegend(legend, route);
 
-    const width = 960;
-    const height = 650;
+    const countries = topojson.feature(worldAtlas, worldAtlas.objects.countries);
+    const countryBorders = topojson.mesh(worldAtlas, worldAtlas.objects.countries, (a, b) => a !== b);
+    const russiaFeature = getRussiaFeature(countries);
 
-    const projectionConfig = route.map || {};
     const projection = d3.geoConicEquidistant()
-      .center(projectionConfig.center || [76, 60])
-      .rotate(projectionConfig.rotate || [-40, 0])
-      .parallels(projectionConfig.parallels || [55, 68])
-      .scale(projectionConfig.scale || 560)
-      .translate(projectionConfig.translate || [470, 315]);
+      .rotate(route?.map?.rotate || [-94, 0])
+      .parallels(route?.map?.parallels || [49, 68.5]);
+
+    if (russiaFeature) {
+      projection.fitExtent([[20, 14], [width - 20, height - 24]], russiaFeature);
+    } else {
+      projection.center([95, 62]).translate([width / 2, height / 2]).scale(530);
+    }
 
     const path = d3.geoPath(projection);
     const graticule = d3.geoGraticule().step([10, 10]);
-
-    const land = topojson.feature(worldAtlas, worldAtlas.objects.land);
-    const countryBorders = topojson.mesh(worldAtlas, worldAtlas.objects.countries, (a, b) => a !== b);
     const lakes = asFeatureCollection(lakesJson);
     const rivers = asFeatureCollection(riversJson);
 
@@ -88,62 +121,40 @@
 
     const mapLayer = svg.append('g').attr('class', 'artist-route-map-layer');
 
-    mapLayer.append('path')
-      .datum({ type: 'Sphere' })
-      .attr('class', 'artist-route-water')
-      .attr('d', path);
-
-    mapLayer.append('path')
-      .datum(graticule())
-      .attr('class', 'artist-route-graticule')
-      .attr('d', path);
-
-    if (rivers) {
-      mapLayer.append('g')
-        .attr('class', 'artist-route-rivers')
-        .selectAll('path')
-        .data(rivers.features)
-        .join('path')
-        .attr('d', path);
-    }
+    mapLayer.append('path').datum({ type: 'Sphere' }).attr('class', 'artist-route-water').attr('d', path);
+    mapLayer.append('path').datum(graticule()).attr('class', 'artist-route-graticule').attr('d', path);
 
     if (lakes) {
-      mapLayer.append('g')
-        .attr('class', 'artist-route-lakes')
-        .selectAll('path')
-        .data(lakes.features)
-        .join('path')
-        .attr('d', path);
+      mapLayer.append('g').attr('class', 'artist-route-lakes').selectAll('path').data(lakes.features).join('path').attr('d', path);
+    }
+    if (rivers) {
+      mapLayer.append('g').attr('class', 'artist-route-rivers').selectAll('path').data(rivers.features).join('path').attr('d', path);
     }
 
-    mapLayer.append('path')
-      .datum(land)
-      .attr('class', 'artist-route-land')
+    mapLayer.append('g')
+      .attr('class', 'artist-route-land-all')
+      .selectAll('path')
+      .data(countries.features)
+      .join('path')
+      .attr('class', (d) => Number(d.id) === 643 ? 'artist-route-land is-russia' : 'artist-route-land is-other')
       .attr('d', path);
 
-    mapLayer.append('path')
-      .datum(countryBorders)
-      .attr('class', 'artist-route-borders')
-      .attr('d', path);
+    mapLayer.append('path').datum(countryBorders).attr('class', 'artist-route-borders').attr('d', path);
 
     const routeLine = {
       type: 'LineString',
       coordinates: route.points.map((point) => [point.lon, point.lat])
     };
 
-    mapLayer.append('path')
-      .datum(routeLine)
-      .attr('class', 'artist-route-line')
-      .attr('d', path);
+    mapLayer.append('path').datum(routeLine).attr('class', 'artist-route-line').attr('d', path);
 
-    const pointsLayer = mapLayer.append('g').attr('class', 'artist-route-points');
-
-    const pointNodes = pointsLayer
+    const pointNodes = mapLayer.append('g')
+      .attr('class', 'artist-route-points')
       .selectAll('circle')
       .data(route.points)
       .join('circle')
       .attr('class', (d) => `artist-route-point period-${d.period || 'base'}`)
-      .attr('r', 5.5)
+      .attr('r', 5.4)
       .attr('fill', (d) => PERIOD_COLORS[d.period] || '#B8894D')
       .attr('transform', (d) => {
         const projected = projection([d.lon, d.lat]);
@@ -153,14 +164,16 @@
       .attr('role', 'button')
       .attr('aria-label', (d) => d.title);
 
-    let activeId = route.map?.activePointId || route.points[0]?.id;
+    let activeId = route.map?.activePointId || route.points[0].id;
 
     function updateDetail(point) {
-      detailTitle.textContent = point.title;
-      detailText.textContent = point.text;
       const periodLabel = route.map?.periodLabels?.[point.period] || point.period || '';
       const categoryLabel = route.map?.categoryLabels?.[point.category] || point.category || '';
+
+      detailTitle.textContent = point.title;
+      detailText.textContent = point.text;
       detailMeta.textContent = [periodLabel, categoryLabel].filter(Boolean).join(' · ');
+      status.textContent = `Равноотстоящий конус · параллели 49° и 68.5° · меридиан 94°E`;
     }
 
     function setActive(id) {
@@ -169,17 +182,14 @@
       activeId = point.id;
       pointNodes
         .classed('is-active', (d) => d.id === activeId)
-        .attr('r', (d) => (d.id === activeId ? 8 : 5.5));
-      chips.querySelectorAll('.artist-route-map-chip').forEach((node) => {
-        node.classList.toggle('is-active', node.getAttribute('data-point-id') === activeId);
-      });
+        .attr('r', (d) => (d.id === activeId ? 8.2 : 5.4));
       updateDetail(point);
     }
 
     function showTooltip(event, point) {
-      const periodLabel = route.map?.periodLabels?.[point.period] || point.period;
+      const periodLabel = route.map?.periodLabels?.[point.period] || point.period || '';
       tooltip.hidden = false;
-      tooltip.innerHTML = `<strong>${point.title}</strong><span>${periodLabel || ''}</span>`;
+      tooltip.innerHTML = `<strong>${point.title}</strong><span>${periodLabel}</span>`;
       const shellRect = mapShell.getBoundingClientRect();
       const x = event.clientX - shellRect.left + 12;
       const y = event.clientY - shellRect.top + 12;
@@ -210,19 +220,6 @@
         }
       });
 
-    chips.innerHTML = route.points.map((point) => `
-      <button type="button" class="artist-route-map-chip" data-point-id="${point.id}" role="listitem">
-        <span class="dot" style="background:${PERIOD_COLORS[point.period] || '#B8894D'}"></span>
-        <span>${point.shortLabel || point.title}</span>
-      </button>
-    `).join('');
-
-    chips.querySelectorAll('.artist-route-map-chip').forEach((chip) => {
-      chip.addEventListener('click', () => {
-        setActive(chip.getAttribute('data-point-id'));
-      });
-    });
-
     const zoomCfg = route.map?.zoom || {};
     const zoomBehavior = d3.zoom()
       .scaleExtent([zoomCfg.min || 1, zoomCfg.max || 7])
@@ -247,20 +244,18 @@
     setActive(activeId);
   }
 
-  Promise.all([
-    loadScript(D3_URL),
-    loadScript(TOPOJSON_URL)
-  ])
+  Promise.all([loadScript(D3_URL), loadScript(TOPOJSON_URL)])
     .then(() => Promise.all([
       fetchJson(ROUTE_JSON_PATH),
       fetchJson(WORLD_ATLAS_URL),
-      fetchJson(LAKES_URL),
-      fetchJson(RIVERS_URL)
+      safeFetchJson(LAKES_URL),
+      safeFetchJson(RIVERS_URL)
     ]))
     .then(([route, worldAtlas, lakes, rivers]) => {
       renderMap(route, worldAtlas, lakes, rivers);
     })
     .catch((error) => {
       console.error('Artist route map error:', error);
+      setModuleStatus('Карта временно недоступна: не удалось загрузить картографические слои.');
     });
 })();

--- a/content-sync.js
+++ b/content-sync.js
@@ -346,7 +346,7 @@
 
     setText('#artist-routes h2', about?.geography?.title);
     if (Array.isArray(about?.geography?.paragraphs)) {
-      document.querySelectorAll('#artist-routes .artist-focus-grid > div p.dark').forEach((p, idx) => {
+      document.querySelectorAll('#artist-routes .artist-route-text p.dark').forEach((p, idx) => {
         if (about.geography.paragraphs[idx]) p.textContent = about.geography.paragraphs[idx];
       });
     }
@@ -385,87 +385,6 @@
 
   }
 
-  function syncRouteMap(routeData) {
-    const section = document.querySelector('#artist-routes');
-    if (!section) return;
-
-    const mapImage = section.querySelector('.artist-route-map-image');
-    const pointsWrap = section.querySelector('.artist-route-map-points');
-    const chipsWrap = section.querySelector('.artist-route-map-chips');
-    const detailTitle = section.querySelector('.artist-route-map-detail h4');
-    const detailText = section.querySelector('.artist-route-map-detail-text');
-    const detailMeta = section.querySelector('.artist-route-map-detail-meta');
-
-    if (!mapImage || !pointsWrap || !chipsWrap || !detailTitle || !detailText || !detailMeta) return;
-
-    const mapData = routeData?.map || {};
-    if (typeof mapData.asset === 'string' && mapData.asset.trim()) {
-      mapImage.src = mapData.asset;
-    }
-
-    const points = Array.isArray(routeData?.points)
-      ? routeData.points.filter((point) => Number.isFinite(Number(point?.x)) && Number.isFinite(Number(point?.y)))
-      : [];
-
-    pointsWrap.innerHTML = '';
-    chipsWrap.innerHTML = '';
-
-    function setActivePoint(pointId) {
-      const active = points.find((item) => item.id === pointId) || points[0];
-      if (!active) {
-        detailTitle.textContent = '';
-        detailText.textContent = '';
-        detailMeta.textContent = '';
-        return;
-      }
-
-      detailTitle.textContent = active.title || '';
-      detailText.textContent = active.text || '';
-      detailMeta.textContent = [active.period, active.kind].filter(Boolean).join(' · ');
-
-      section.querySelectorAll('[data-route-point-id]').forEach((node) => {
-        const isActive = node.dataset.routePointId === active.id;
-        node.classList.toggle('is-active', isActive);
-        node.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-      });
-    }
-
-    points.forEach((point, index) => {
-      const pointId = point.id || `route-point-${index}`;
-      const x = Math.max(0, Math.min(100, Number(point.x)));
-      const y = Math.max(0, Math.min(100, Number(point.y)));
-
-      const marker = document.createElement('button');
-      marker.type = 'button';
-      marker.className = 'artist-route-marker';
-      marker.dataset.routePointId = pointId;
-      marker.style.left = `${x}%`;
-      marker.style.top = `${y}%`;
-      marker.setAttribute('role', 'listitem');
-      marker.setAttribute('aria-label', point.title || point.shortLabel || `Точка ${index + 1}`);
-      marker.setAttribute('aria-pressed', 'false');
-      marker.innerHTML = '<span aria-hidden="true"></span>';
-
-      const chip = document.createElement('button');
-      chip.type = 'button';
-      chip.className = 'artist-route-chip';
-      chip.dataset.routePointId = pointId;
-      chip.setAttribute('role', 'listitem');
-      chip.setAttribute('aria-pressed', 'false');
-      chip.textContent = point.title || point.shortLabel || `Точка ${index + 1}`;
-
-      [marker, chip].forEach((control) => {
-        control.addEventListener('click', () => setActivePoint(pointId));
-        control.addEventListener('focus', () => setActivePoint(pointId));
-      });
-
-      pointsWrap.appendChild(marker);
-      chipsWrap.appendChild(chip);
-    });
-
-    setActivePoint(points[0]?.id);
-  }
-
   function syncVisit(visit) {
     if (!visit) return;
     setText('#page-visit .page-hero-label', visit?.hero?.label || 'Посещение');
@@ -484,16 +403,14 @@
     fetchJson(JSON_PATHS.home),
     fetchJson(JSON_PATHS.exhibition),
     fetchJson(JSON_PATHS.about),
-    fetchJson(JSON_PATHS.visit),
-    fetchJson(JSON_PATHS.route)
+    fetchJson(JSON_PATHS.visit)
   ])
-    .then(([site, home, exhibition, about, visit, route]) => {
+    .then(([site, home, exhibition, about, visit]) => {
       syncShared(site);
       syncHome(home);
       syncExhibition(exhibition);
       syncAbout(about);
       syncVisit(visit);
-      syncRouteMap(route);
       window.__contentSyncReady = true;
     })
     .catch((error) => {

--- a/pages/artist.html
+++ b/pages/artist.html
@@ -86,18 +86,29 @@
                     <p class="dark"></p>
                     <p class="dark"></p>
                 </div>
-                <aside class="artist-route-map-card" aria-label="Карта маршрутов художника">
-                    <div class="artist-route-map-shell">
-                        <div class="artist-route-map-canvas" role="img" aria-label="Карта России с маршрутами художника"></div>
-                        <div class="artist-route-map-tooltip" role="status" aria-live="polite" hidden></div>
+
+                <div id="wrap" class="artist-route-map-module" aria-label="Карта маршрутов художника">
+                    <div id="head" class="artist-route-map-head">
+                        <h3 class="artist-route-map-title">География маршрутов</h3>
+                        <div class="artist-route-map-actions" role="group" aria-label="Управление картой">
+                            <button type="button" data-zoom="in" aria-label="Увеличить карту">+</button>
+                            <button type="button" data-zoom="out" aria-label="Уменьшить карту">−</button>
+                            <button type="button" class="artist-route-map-reset">Сброс</button>
+                        </div>
                     </div>
-                    <div class="artist-route-map-chips" role="list" aria-label="Точки маршрута"></div>
-                    <div class="artist-route-map-detail" aria-live="polite">
-                        <h4></h4>
-                        <p class="artist-route-map-detail-text"></p>
-                        <p class="artist-route-map-detail-meta"></p>
+                    <div id="map-container" class="artist-route-map-shell">
+                        <div id="msvg" class="artist-route-map-canvas" role="img" aria-label="Карта России с маршрутами художника"></div>
+                        <div id="mtip" class="artist-route-map-tooltip" role="status" aria-live="polite" hidden></div>
                     </div>
-                </aside>
+                    <p id="mstatus" class="artist-route-map-status" aria-live="polite"></p>
+                    <div id="mleg" class="artist-route-map-legend" aria-label="Легенда карты"></div>
+                </div>
+
+                <div class="artist-route-map-detail" aria-live="polite">
+                    <h4></h4>
+                    <p class="artist-route-map-detail-text"></p>
+                    <p class="artist-route-map-detail-meta"></p>
+                </div>
             </div>
         </section>
 

--- a/styles.css
+++ b/styles.css
@@ -1492,38 +1492,65 @@
             text-transform: uppercase;
         }
 
-        .artist-route-text {
+        #page-artist #artist-routes .artist-route-text {
             max-width: 960px;
         }
-        .artist-route-map-card {
-            background: #fff;
-            border: 1px solid var(--border-light);
-            padding: 18px;
-            display: grid;
-            gap: 14px;
-            min-width: 0;
-            align-content: start;
+        #page-artist #artist-routes .artist-route-map-module {
             width: 100%;
-            margin-top: 24px;
-        }
-        .artist-route-map-shell {
-            position: relative;
-            width: 100%;
-            aspect-ratio: 960 / 650;
-            border: 1px solid rgba(18,28,57,0.16);
-            background: #edf2f7;
+            margin-top: 28px;
+            border: 1px solid rgba(167, 147, 102, 0.45);
+            border-radius: 18px;
+            background: #d8cec0;
             overflow: hidden;
         }
-        .artist-route-map-canvas {
-            width: 100%;
-            height: 100%;
+        #page-artist #artist-routes #head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            padding: 14px 16px;
+            background: linear-gradient(180deg, rgba(17, 12, 4, 0.96), rgba(21, 15, 5, 0.96));
+            border-bottom: 1px solid rgba(184, 143, 58, 0.4);
         }
-        .artist-route-map-svg {
+        #page-artist #artist-routes .artist-route-map-title {
+            margin: 0;
+            color: #e8e4df;
+            font-family: var(--serif);
+            font-size: clamp(20px, 2.2vw, 26px);
+            font-weight: 400;
+        }
+        #page-artist #artist-routes .artist-route-map-actions {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+        #page-artist #artist-routes .artist-route-map-actions button {
+            border: 1px solid rgba(232, 228, 223, 0.35);
+            background: rgba(232, 228, 223, 0.08);
+            color: #f6f2eb;
+            padding: 6px 10px;
+            min-width: 38px;
+            font-size: 13px;
+            border-radius: 3px;
+            cursor: pointer;
+        }
+        #page-artist #artist-routes #map-container {
+            position: relative;
+            width: 100%;
+            min-height: 620px;
+            max-width: 100%;
+            border-bottom: 1px solid rgba(113, 88, 38, 0.4);
+            overflow: hidden;
+            background: #aac0d0;
+        }
+        #page-artist #artist-routes #msvg,
+        #page-artist #artist-routes .artist-route-map-svg {
             display: block;
             width: 100%;
             height: 100%;
+            max-width: 100%;
         }
-        .artist-route-map-tooltip {
+        #page-artist #artist-routes #mtip {
             position: absolute;
             z-index: 6;
             pointer-events: none;
@@ -1537,113 +1564,424 @@
             box-shadow: 0 10px 20px rgba(18,28,57,0.24);
             transform: translate(-9999px, -9999px);
         }
-        .artist-route-map-tooltip strong {
+        #page-artist #artist-routes #mtip strong { font-size: 13px; font-weight: 500; }
+        #page-artist #artist-routes #mtip span { color: rgba(255,255,255,0.82); }
+        #page-artist #artist-routes #mstatus {
+            margin: 0;
+            padding: 10px 16px;
+            font-size: 12px;
+            color: #a78849;
+            border-bottom: 1px solid rgba(184, 143, 58, 0.35);
+            background: #140d04;
+        }
+        #page-artist #artist-routes #mleg {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px 14px;
+            padding: 12px 16px 16px;
+            background: #140d04;
+        }
+        #page-artist #artist-routes .artist-route-map-legend-item {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            color: #b08a47;
             font-size: 13px;
-            font-weight: 500;
         }
-        .artist-route-map-tooltip span {
-            color: rgba(255,255,255,0.82);
+        #page-artist #artist-routes .artist-route-map-legend-item .dot {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            flex: 0 0 auto;
         }
-        .artist-route-water {
-            fill: #e9f0f6;
-        }
-        .artist-route-graticule {
-            fill: none;
-            stroke: rgba(37,53,87,0.18);
-            stroke-width: 0.6;
-        }
-        .artist-route-rivers path {
-            fill: none;
-            stroke: rgba(72,126,173,0.35);
-            stroke-width: 0.9;
-        }
-        .artist-route-lakes path {
-            fill: rgba(130,174,204,0.55);
-            stroke: rgba(72,126,173,0.4);
-            stroke-width: 0.5;
-        }
-        .artist-route-land {
-            fill: #f4efe6;
-            stroke: rgba(58,66,84,0.36);
-            stroke-width: 0.8;
-        }
-        .artist-route-borders {
-            fill: none;
-            stroke: rgba(58,66,84,0.28);
-            stroke-width: 0.5;
-        }
-        .artist-route-line {
-            fill: none;
-            stroke: rgba(122,84,46,0.7);
-            stroke-width: 1.5;
-            stroke-linejoin: round;
-            stroke-linecap: round;
-            stroke-dasharray: 4 3;
-        }
-        .artist-route-point {
-            stroke: #fbf7f0;
-            stroke-width: 2.2;
+        #page-artist #artist-routes .artist-route-water { fill: #aac0d0; }
+        #page-artist #artist-routes .artist-route-graticule { fill: none; stroke: rgba(78, 119, 152, 0.24); stroke-width: 0.65; }
+        #page-artist #artist-routes .artist-route-rivers path { fill: none; stroke: rgba(89, 139, 178, 0.86); stroke-width: 1.1; }
+        #page-artist #artist-routes .artist-route-lakes path { fill: rgba(145, 188, 216, 0.82); stroke: rgba(89, 139, 178, 0.72); stroke-width: 0.55; }
+        #page-artist #artist-routes .artist-route-land.is-russia { fill: #d8ceb8; stroke: rgba(72, 112, 147, 0.62); stroke-width: 0.9; }
+        #page-artist #artist-routes .artist-route-land.is-other { fill: #c8c3ad; stroke: rgba(126, 112, 84, 0.45); stroke-width: 0.7; }
+        #page-artist #artist-routes .artist-route-borders { fill: none; stroke: rgba(95, 133, 166, 0.52); stroke-width: 0.55; }
+        #page-artist #artist-routes .artist-route-line { fill: none; stroke: rgba(173, 125, 48, 0.7); stroke-width: 1.8; stroke-linejoin: round; stroke-linecap: round; stroke-dasharray: 4 3; }
+        #page-artist #artist-routes .artist-route-point {
+            stroke: rgba(248, 239, 223, 0.95);
+            stroke-width: 1.8;
             cursor: pointer;
             transition: r 0.15s ease, opacity 0.15s ease;
         }
-        .artist-route-point.is-hover,
-        .artist-route-point.is-active {
-            opacity: 1;
+        #page-artist #artist-routes .artist-route-point.is-hover,
+        #page-artist #artist-routes .artist-route-point.is-active { opacity: 1; }
+        #page-artist #artist-routes .artist-route-point:not(.is-active):not(.is-hover) { opacity: 0.86; }
+        #page-artist #artist-routes .artist-route-map-detail {
+            margin-top: 16px;
+            background: #fff;
+            border: 1px solid var(--border-light);
+            padding: 16px;
         }
-        .artist-route-point:not(.is-active):not(.is-hover) {
-            opacity: 0.86;
-        }
-        .artist-route-map-chips {
-            margin: 0;
-            padding: 0;
-            list-style: none;
-            display: flex;
-            flex-wrap: wrap;
-            gap: 8px;
-        }
-        .artist-route-map-chip {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            font-size: 12px;
-            color: var(--text-muted);
-            min-width: 0;
-            border: 1px solid rgba(18,28,57,0.16);
-            background: #f8f5ef;
-            border-radius: 999px;
-            padding: 5px 10px;
-            cursor: pointer;
-            transition: background-color 0.2s ease, border-color 0.2s ease;
-        }
-        .artist-route-map-chip .dot {
-            width: 10px;
-            height: 10px;
-            border-radius: 999px;
-            flex: 0 0 auto;
-        }
-        .artist-route-map-chip.is-active {
-            background: #f0e7da;
-            border-color: rgba(122,84,46,0.5);
-            color: var(--deep-blue);
-        }
-        .artist-route-map-detail h4 {
+        #page-artist #artist-routes .artist-route-map-detail h4 {
             margin: 0 0 6px;
             font-family: var(--serif);
             font-size: 20px;
             color: var(--deep-blue);
             font-weight: 400;
         }
-        .artist-route-map-detail-text {
+        #page-artist #artist-routes .artist-route-map-detail-text {
             margin: 0;
             font-size: 14px;
             line-height: 1.6;
             color: var(--text-muted);
         }
-        .artist-route-map-detail-meta {
+        #page-artist #artist-routes .artist-route-map-detail-meta {
             margin: 8px 0 0;
             font-size: 12px;
             color: var(--gold-muted);
             letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
+
+        .artist-method-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+            .artist-archive-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+            .artist-toc { position: static; }
+            #page-home .home-row--split { grid-template-columns: 1fr; }
+            #page-home .home-grid-item,
+            #page-home .home-intro-compact,
+            #page-home .home-compact { padding-top: 48px; padding-bottom: 48px; }
+            #page-home .home-memory-quiet { padding-top: 32px; padding-bottom: 32px; }
+        }
+        @media (max-width: 900px) {
+            .nav { padding: 0 24px; }
+            .nav-center { display: none; }
+            .nav-btn { display: none; }
+            .nav-burger { display: block; }
+            .hero {
+                grid-template-columns: 1fr;
+                padding: 120px 24px 60px;
+            }
+            .hero-visual { order: -1; }
+            .hero-visual-frame { aspect-ratio: var(--artwork-ratio); }
+            .hero-scroll { display: none; }
+            .section-light, .section-dark, .section-cool, .section-burgundy { padding: 80px 24px; }
+            .artist-grid,
+            .visit-grid { grid-template-columns: 1fr; gap: 40px; }
+            .works-grid { grid-template-columns: 1fr 1fr; gap: 20px; }
+            .hero-meta { gap: 24px; }
+            .footer { padding: 56px 24px 32px; }
+            .footer-top { grid-template-columns: 1fr; gap: 32px; }
+            .footer-nav { justify-self: start; }
+            .geo-inner { flex-direction: column; text-align: center; }
+            .artist-intro-main { padding: 22px; }
+            .artist-theme-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+            #page-home .home-intro-compact,
+#page-home .home-compact { padding-top: 42px; padding-bottom: 42px; }
+#page-home .home-memory-quiet { padding-top: 28px; padding-bottom: 28px; }
+#page-home .home-artist-teaser .artist-grid { grid-template-columns: 1fr; gap: 22px; }
+#page-home .home-digital-hub .digital-blocks { grid-template-columns: 1fr; }
+        }
+        @media (max-width: 560px) {
+            .works-grid { grid-template-columns: 1fr; }
+            .hero-buttons { flex-direction: column; }
+            .hero-buttons .btn { width: 100%; justify-content: center; }
+            .artist-method-grid { grid-template-columns: 1fr; }
+            .artist-archive-grid { grid-template-columns: 1fr; }
+            .artist-theme-grid { grid-template-columns: 1fr; }
+        }
+
+        /* ── Page transitions ── */
+        .page {
+            display: none;
+            min-height: 100vh;
+        }
+        .page.active {
+            display: block;
+        }
+        .page-enter {
+            animation: pageIn 0.5s ease forwards;
+        }
+        @keyframes pageIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        /* ── Inner page hero (compact) ── */
+        .page-hero {
+            background: var(--deep-blue);
+            padding: 140px 48px 72px;
+            position: relative;
+            overflow: hidden;
+            z-index: 1;
+        }
+        .page-hero::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(135deg, rgba(18,28,57,0.97) 0%, rgba(18,28,57,0.85) 100%);
+            z-index: 0;
+        }
+        .page-hero .hero-texture {
+            z-index: 0;
+        }
+        .page-hero .container {
+            position: relative;
+            z-index: 1;
+        }
+        .page-hero-label {
+            font-family: var(--sans);
+            font-size: 11px;
+            font-weight: 500;
+            color: var(--gold);
+            letter-spacing: 0.2em;
+            text-transform: uppercase;
+            margin-bottom: 20px;
+        }
+        .page-hero h1 {
+            font-family: var(--serif);
+            font-size: clamp(32px, 4.5vw, 56px);
+            font-weight: 400;
+            color: #fff;
+            line-height: 1.15;
+            margin-bottom: 16px;
+        }
+        .page-hero h1 em {
+            font-style: italic;
+            color: var(--gold);
+        }
+        .page-hero-subtitle {
+            font-family: var(--serif);
+            font-size: clamp(16px, 2vw, 22px);
+            font-weight: 400;
+            font-style: italic;
+            color: var(--text-light);
+            line-height: 1.4;
+            max-width: 640px;
+        }
+        #page-exhibition .page-hero {
+            padding-top: 120px;
+            padding-bottom: 48px;
+        }
+        #page-exhibition .content-section:first-of-type {
+            padding-top: 56px;
+        }
+
+        /* ── Breadcrumbs ── */
+        .breadcrumbs {
+            padding: 20px 48px;
+            background: var(--museum-bg-cool);
+            border-bottom: 1px solid var(--border-light);
+            position: relative;
+            z-index: 1;
+        }
+        .breadcrumbs-inner {
+            max-width: 1200px;
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-family: var(--sans);
+            font-size: 12px;
+            color: var(--text-muted);
+        }
+        .breadcrumbs a {
+            color: var(--text-muted);
+            text-decoration: none;
+            transition: color 0.2s;
+        }
+        .breadcrumbs a:hover {
+            color: var(--deep-blue);
+        }
+        .breadcrumbs .sep {
+            color: var(--text-muted);
+            opacity: 0.4;
+            font-size: 10px;
+        }
+        .breadcrumbs .current {
+            color: var(--deep-blue);
+            font-weight: 500;
+        }
+
+        /* ── Content blocks for inner pages ── */
+        .content-section {
+            padding: 80px 48px;
+            position: relative;
+            z-index: 1;
+        }
+        .content-section.bg-light { background: var(--museum-bg); }
+        .content-section.bg-cool { background: var(--museum-bg-cool); }
+        .content-section.bg-dark { background: var(--deep-blue); }
+        .content-section.bg-burgundy { background: var(--burgundy); }
+
+        .content-block {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+        .content-block + .content-block {
+            margin-top: 64px;
+        }
+
+        .content-two-col {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 64px;
+            align-items: start;
+        }
+
+        .content-narrow {
+            max-width: 760px;
+        }
+
+        .content-block h2 {
+            font-family: var(--serif);
+            font-size: clamp(24px, 3.5vw, 40px);
+            font-weight: 400;
+            line-height: 1.2;
+            margin-bottom: 12px;
+        }
+        .content-block h2.dark { color: var(--deep-blue); }
+        .content-block h2.light { color: #fff; }
+
+        .content-block h3 {
+            font-family: var(--serif);
+            font-size: 22px;
+            font-weight: 400;
+            line-height: 1.3;
+            margin-bottom: 16px;
+        }
+        .content-block h3.dark { color: var(--deep-blue); }
+        .content-block h3.light { color: #fff; }
+
+        .content-block .subtitle {
+            font-family: var(--serif);
+            font-size: 18px;
+            font-weight: 400;
+            font-style: italic;
+            line-height: 1.4;
+            margin-bottom: 20px;
+        }
+        .content-block .subtitle.dark { color: var(--text-muted); }
+        .content-block .subtitle.light { color: var(--text-light); }
+
+        .content-block p {
+            font-family: var(--sans);
+            font-size: 15px;
+            font-weight: 300;
+            line-height: 1.8;
+            margin-bottom: 20px;
+        }
+        .content-block p.dark { color: var(--text-muted); }
+        .content-block p.light { color: var(--text-light); }
+
+        .content-block .quote {
+            font-family: var(--serif);
+            font-size: 20px;
+            font-style: italic;
+            line-height: 1.5;
+            padding: 32px 0 32px 32px;
+            border-left: 3px solid var(--gold);
+            margin: 32px 0;
+            color: var(--deep-blue);
+        }
+
+        /* ── Artist page: dossier layout ── */
+        #page-artist .page-hero {
+            padding-top: 124px;
+            padding-bottom: 52px;
+        }
+        .artist-dossier-layout {
+            display: grid;
+            grid-template-columns: minmax(0, 240px) 1fr;
+            gap: 40px;
+            align-items: start;
+        }
+        .artist-toc {
+            position: sticky;
+            top: 92px;
+            padding: 20px 18px;
+            background: #fff;
+            border: 1px solid var(--border-light);
+            border-radius: 2px;
+        }
+        .artist-toc h3 {
+            font-family: var(--sans);
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+            color: var(--gold-muted);
+            margin-bottom: 14px;
+        }
+        .artist-toc button {
+            display: block;
+            font-family: var(--sans);
+            font-size: 13px;
+            color: var(--text-muted);
+            text-align: left;
+            width: 100%;
+            background: none;
+            border: none;
+            cursor: pointer;
+            padding: 7px 0;
+            border-top: 1px solid rgba(0,0,0,0.04);
+            transition: color 0.2s ease;
+        }
+        .artist-toc button:hover { color: var(--deep-blue); }
+        .artist-toc button:first-of-type { border-top: none; }
+
+        .artist-intro-main {
+            background: #fff;
+            border: 1px solid var(--border-light);
+            padding: 32px;
+        }
+        .artist-intro-headline {
+            font-family: var(--serif);
+            font-size: clamp(24px, 3vw, 34px);
+            font-style: italic;
+            line-height: 1.35;
+            color: var(--deep-blue);
+            margin-bottom: 28px;
+        }
+        .artist-intro-grid {
+            display: grid;
+            grid-template-columns: minmax(0, 340px) 1fr;
+            gap: 36px;
+            align-items: start;
+        }
+        .artist-intro-text p {
+            color: var(--text-muted);
+            margin-bottom: 16px;
+        }
+
+        .artist-life-geo-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 28px;
+        }
+        .artist-module {
+            background: rgba(255,255,255,0.75);
+            border: 1px solid var(--border-light);
+            padding: 28px;
+        }
+        .artist-module h3 {
+            margin-bottom: 20px;
+        }
+        .artist-map-placeholder {
+            margin-top: 20px;
+            aspect-ratio: 4/3;
+            background: var(--deep-blue);
+            border: 1px solid var(--border-dark);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+        }
+        .artist-map-placeholder i {
+            color: var(--gold-muted);
+            opacity: 0.5;
+            font-size: 34px;
+        }
+        .artist-map-placeholder span {
+            color: var(--text-light);
+            opacity: 0.55;
+            font-size: 11px;
+            letter-spacing: 0.1em;
             text-transform: uppercase;
         }
 
@@ -1842,9 +2180,15 @@
             .artist-life-geo-grid {
                 grid-template-columns: 1fr;
             }
-            .artist-route-map-card {
-                padding: 14px;
-                margin-top: 18px;
+            #page-artist #artist-routes .artist-route-map-module {
+                margin-top: 20px;
+            }
+            #page-artist #artist-routes #head {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            #page-artist #artist-routes #map-container {
+                min-height: 440px;
             }
             .artist-diptych {
                 grid-template-columns: 1fr;
@@ -1872,8 +2216,11 @@
             .artist-theme-grid {
                 grid-template-columns: 1fr;
             }
-            .artist-route-map-chip {
-                font-size: 11px;
+            #page-artist #artist-routes #map-container {
+                min-height: 360px;
+            }
+            #page-artist #artist-routes #mleg {
+                gap: 8px 10px;
             }
         }
 


### PR DESCRIPTION
### Motivation
- Replace the legacy static map/card implementation with an interactive, self-contained map module that supports zooming, a legend, and more robust data loading and projection behavior.
- Improve UX and accessibility by moving map controls and detail panel into clearer DOM structure and keeping the detail area live-region friendly.
- Make optional cartographic layers resilient to network failures so the map can still render when lakes or rivers fail to load.
- Update visual styling and color palette to match the redesigned artist page layout.

### Description
- Reworked `artist-route-map.js` to create a new module-style interface, added helper functions `safeFetchJson`, `setModuleStatus`, `getRussiaFeature`, and `buildLegend`, and changed DOM selectors to the new markup (`#page-artist #artist-routes` and element IDs like `#msvg`, `#mtip`, `#mstatus`, `#mleg`).
- Adjusted geographic logic to use `d3.geoConicEquidistant` with `projection.fitExtent` when the Russia feature is present and fallback `center/translate/scale` otherwise, and updated route/point rendering details (radii, classes, tooltips, and aria attributes).
- Use `safeFetchJson` for optional layers (lakes and rivers) and show a localized module status message via `setModuleStatus` when the map fails to initialize.
- Removed the old `syncRouteMap` and associated sync logic from `content-sync.js`, and updated page markup in `pages/artist.html` to the new module structure and moved the detail panel outside the module; added extensive CSS rules in `styles.css` to style the module, legend, status bar, and responsive behaviors.

### Testing
- Ran the project's lint and build steps via `npm run lint` and `npm run build`, and the build completed successfully with no errors.
- Executed the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4f5ce1d788322828ec32f9ea7653d)