### PR TITLE
Align /artist route map projection runtime with JSON config

### DIFF
--- a/artist-route-map.js
+++ b/artist-route-map.js
@@ -35,6 +35,13 @@
     south: '#C46A31'
   };
 
+  const PROJECTION_FACTORIES = {
+    conicEquidistant: () => window.d3.geoConicEquidistant(),
+    mercator: () => window.d3.geoMercator(),
+    naturalEarth1: () => window.d3.geoNaturalEarth1(),
+    equalEarth: () => window.d3.geoEqualEarth()
+  };
+
   function setModuleStatus(message) {
     const status = document.querySelector('#page-artist #artist-routes #mstatus');
     if (status) status.textContent = message;
@@ -116,6 +123,76 @@
 
   function getRussiaFeature(countriesFeatureCollection) {
     return countriesFeatureCollection?.features?.find((feature) => Number(feature?.id) === 643) || null;
+  }
+
+  function toFiniteNumber(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+  }
+
+  function toPair(values) {
+    if (!Array.isArray(values) || values.length < 2) return null;
+    const first = toFiniteNumber(values[0]);
+    const second = toFiniteNumber(values[1]);
+    if (first == null || second == null) return null;
+    return [first, second];
+  }
+
+  function createProjection(route, russiaFeature, width, height) {
+    const d3 = window.d3;
+    const projectionName = route?.map?.projection;
+    const projectionFactory = PROJECTION_FACTORIES[projectionName] || PROJECTION_FACTORIES.conicEquidistant;
+    const projection = projectionFactory();
+
+    const rotate = toPair(route?.map?.rotate);
+    const parallels = toPair(route?.map?.parallels);
+    const center = toPair(route?.map?.center);
+    const scale = toFiniteNumber(route?.map?.scale);
+    const translate = toPair(route?.map?.translate);
+
+    if (typeof projection.rotate === 'function' && rotate) projection.rotate(rotate);
+    if (typeof projection.parallels === 'function' && parallels) projection.parallels(parallels);
+    if (typeof projection.center === 'function' && center) projection.center(center);
+    if (typeof projection.scale === 'function' && scale) projection.scale(scale);
+    if (typeof projection.translate === 'function' && translate) projection.translate(translate);
+
+    const hasManualScale = scale != null;
+    const hasManualTranslate = translate != null;
+
+    if (!hasManualScale && !hasManualTranslate && russiaFeature) {
+      projection.fitExtent([[20, 14], [width - 20, height - 24]], russiaFeature);
+    } else if (!hasManualTranslate && typeof projection.translate === 'function') {
+      projection.translate([width / 2, height / 2]);
+    }
+
+    if (!hasManualScale && typeof projection.scale === 'function') {
+      const currentScale = toFiniteNumber(projection.scale());
+      if (currentScale == null) projection.scale(530);
+    }
+
+    return projection;
+  }
+
+  function describeProjection(route) {
+    const projectionName = route?.map?.projection || 'conicEquidistant';
+    const rotate = toPair(route?.map?.rotate);
+    const parallels = toPair(route?.map?.parallels);
+
+    const titleMap = {
+      conicEquidistant: 'Равноотстоящий конус',
+      mercator: 'Меркатор',
+      naturalEarth1: 'Natural Earth',
+      equalEarth: 'Equal Earth'
+    };
+
+    const parts = [titleMap[projectionName] || projectionName];
+    if (parallels) {
+      parts.push(`параллели ${parallels[0]}° и ${parallels[1]}°`);
+    }
+    if (rotate) {
+      parts.push(`меридиан ${Math.abs(rotate[0])}°${rotate[0] < 0 ? 'E' : 'W'}`);
+    }
+    return parts.join(' · ');
   }
 
   function buildLegend(host, route) {
@@ -231,15 +308,7 @@
     const countryBorders = topojson.mesh(worldAtlas, worldAtlas.objects.countries, (a, b) => a !== b);
     const russiaFeature = getRussiaFeature(countries);
 
-    const projection = d3.geoConicEquidistant()
-      .rotate(route?.map?.rotate || [-94, 0])
-      .parallels(route?.map?.parallels || [49, 68.5]);
-
-    if (russiaFeature) {
-      projection.fitExtent([[20, 14], [width - 20, height - 24]], russiaFeature);
-    } else {
-      projection.center([95, 62]).translate([width / 2, height / 2]).scale(530);
-    }
+    const projection = createProjection(route, russiaFeature, width, height);
 
     const path = d3.geoPath(projection);
     const graticule = d3.geoGraticule().step([10, 10]);
@@ -306,7 +375,7 @@
       detailTitle.textContent = point.title;
       detailText.textContent = point.text;
       detailMeta.textContent = [periodLabel, categoryLabel].filter(Boolean).join(' · ');
-      status.textContent = 'Равноотстоящий конус · параллели 49° и 68.5° · меридиан 94°E';
+      status.textContent = describeProjection(route);
     }
 
     function setActive(id) {

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,5 +1,5 @@
 (function bootstrapApp() {
-    const BUILD_ID = '2026-04-06-route-map-v4';
+    const BUILD_ID = '2026-04-08-route-map-v5';
 
     function withBuildId(path) {
         const separator = path.includes('?') ? '&' : '?';

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta property="og:type" content="website">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=2026-04-05-route-map-v4">
+    <link rel="stylesheet" href="styles.css?v=2026-04-08-route-map-v5">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
@@ -25,6 +25,6 @@
     <div id="pages-root"></div>
     <div id="component-footer"></div>
 
-    <script src="bootstrap.js?v=2026-04-05-route-map-v4"></script>
+    <script src="bootstrap.js?v=2026-04-08-route-map-v5"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- `09_SOURCE_JSON/pages/route.json` already contains projection and map metadata, but the runtime renderer used a hardcoded conic-projection flow and fixed status text instead of honoring the JSON source of truth.
- The change preserves the existing bootstrap/content-sync/app routing architecture while making projection behavior configurable from `route.json` and keeping robust fallbacks for offline/partial CDN availability.

### Description
- In `artist-route-map.js` added projection factories, safe numeric parsing helpers, `createProjection` and `describeProjection` so the renderer respects `projection`, `rotate`, `parallels`, `center`, `scale`, and `translate` coming from `route.json`.
- Replaced the previous hardcoded conic projection and fixed status string with calls to `createProjection(route, ...)` and `describeProjection(route)` so `route.json` becomes the effective source of truth for projection behavior.
- Kept existing graceful fallback (local SVG + point overlay) and the same init order (bootstrap -> content-sync -> artist-route-map -> app), avoiding any HTML-first insertion or iframe usage.
- Bumped cache-busting build id in `bootstrap.js` and updated `index.html` stylesheet/script query strings to force consumers to pick up the runtime change.

Files changed: `artist-route-map.js` (projection/runtime improvements), `bootstrap.js` (build id bump), `index.html` (cache-bust string).

### Testing
- Ran `node --check artist-route-map.js` and it completed without syntax errors (OK).
- Ran `node --check bootstrap.js` and it completed without syntax errors (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69c542c848322b1c33b90726b93cd)