### PR TITLE
Fix artist route map layout, add responsive CSS, and bump build id

### DIFF
--- a/09_SOURCE_JSON/pages/route.json
+++ b/09_SOURCE_JSON/pages/route.json
@@ -4,11 +4,8 @@
   "map": {
     "activePointId": "spb",
     "projection": "conicEquidistant",
-    "center": [76, 60],
-    "rotate": [-40, 0],
-    "parallels": [55, 68],
-    "scale": 560,
-    "translate": [470, 315],
+    "rotate": [-94, 0],
+    "parallels": [49, 68.5],
     "zoom": {
       "min": 1,
       "max": 7,

--- a/artist-route-map-fix.css
+++ b/artist-route-map-fix.css
@@ -1,0 +1,28 @@
+#page-artist #artist-routes #map-container {
+    height: 620px;
+    min-height: 0;
+}
+
+#page-artist #artist-routes #msvg {
+    position: absolute;
+    inset: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+}
+
+#page-artist #artist-routes .artist-route-map-svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+}
+
+@media (max-width: 768px) {
+    #page-artist #artist-routes #map-container { height: 440px; }
+}
+
+@media (max-width: 480px) {
+    #page-artist #artist-routes #map-container { height: 360px; }
+}

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,5 +1,5 @@
 (function bootstrapApp() {
-    const BUILD_ID = '2026-04-08-route-map-v5';
+    const BUILD_ID = '2026-04-09-route-map-v6';
 
     function withBuildId(path) {
         const separator = path.includes('?') ? '&' : '?';

--- a/index.html
+++ b/index.html
@@ -11,7 +11,8 @@
     <meta property="og:type" content="website">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=2026-04-08-route-map-v5">
+    <link rel="stylesheet" href="styles.css?v=2026-04-09-route-map-v6">
+    <link rel="stylesheet" href="artist-route-map-fix.css?v=2026-04-09-route-map-v6">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
@@ -25,6 +26,6 @@
     <div id="pages-root"></div>
     <div id="component-footer"></div>
 
-    <script src="bootstrap.js?v=2026-04-08-route-map-v5"></script>
+    <script src="bootstrap.js?v=2026-04-09-route-map-v6"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation

- Adjust the map projection and layout for the artist route page so the map displays correctly across viewports and the SVG overlays are positioned and sized reliably.
- Ensure the new styles are included and cache-busted by updating the build id used in asset URLs.

### Description

- Modified `09_SOURCE_JSON/pages/route.json` to change map projection parameters by updating `rotate` and `parallels` and removing explicit `center`, `scale`, and `translate` settings to improve map rendering.
- Added `artist-route-map-fix.css` to set fixed container heights, responsive breakpoints, and ensure the map SVG (`#msvg` and `.artist-route-map-svg`) fills its container and is positioned absolutely.
- Bumped the `BUILD_ID` in `bootstrap.js` to `2026-04-09-route-map-v6` and updated `index.html` to reference the new `styles.css` version query and include `artist-route-map-fix.css`, and also updated the script tag to use the new build id.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7801422cc8322bffc3c516657f546)