### PR TITLE
Hide artist route SVG strokes and bump build/version to v8

### DIFF
--- a/artist-route-map-fix.css
+++ b/artist-route-map-fix.css
@@ -26,3 +26,8 @@
 @media (max-width: 480px) {
     #page-artist #artist-routes #map-container { height: 360px; }
 }
+#page-artist #artist-routes .artist-route-line {
+    stroke: transparent !important;
+    stroke-width: 0 !important;
+    fill: none !important;
+}

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,5 +1,5 @@
 (function bootstrapApp() {
-    const BUILD_ID = '2026-04-10-route-map-v7';
+    const BUILD_ID = '2026-04-10-route-map-v8';
 
     function withBuildId(path) {
         const separator = path.includes('?') ? '&' : '?';

--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
     <meta property="og:type" content="website">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=2026-04-10-route-map-v7">
-    <link rel="stylesheet" href="artist-route-map-fix.css?v=2026-04-10-route-map-v7">
+    <link rel="stylesheet" href="styles.css?v=2026-04-10-route-map-v8">
+    <link rel="stylesheet" href="artist-route-map-fix.css?v=2026-04-10-route-map-v8">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
@@ -26,6 +26,6 @@
     <div id="pages-root"></div>
     <div id="component-footer"></div>
 
-    <script src="bootstrap.js?v=2026-04-10-route-map-v7"></script>
+    <script src="bootstrap.js?v=2026-04-10-route-map-v8"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Prevent visible stroke artifacts on the artist route SVG and ensure clients receive the updated assets by bumping the build id for cache invalidation.

### Description
- Add CSS rules for `#page-artist #artist-routes .artist-route-line` to set `stroke: transparent`, `stroke-width: 0`, and `fill: none`, and update `BUILD_ID` in `bootstrap.js` and the asset query params in `index.html` from `v7` to `v8`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e1fa16b48322934ca9e24d9b06ff)