### PR TITLE
Replace hero placeholder with poster on home page

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -19,8 +19,7 @@
         <div class="hero-visual">
             <div class="hero-visual-frame">
                 <div class="hero-visual-inner">
-                    <i class="fa-solid fa-image"></i>
-                    <span>Фрагмент живописи</span>
+                    <img src="assets/posters/poster_correct_home.webp" alt="Фрагмент живописи">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Motivation
- Заменить декоративную заглушку в правой части hero-секции на настоящий постер на главной странице, сохранив текст слева и минимально изменив код.

### Description
- Изменён только `pages/home.html`: внутри блока `.hero-visual-inner` удалена иконка и подпись и вставлен тег `<img src="assets/posters/poster_correct_home.webp" alt="Фрагмент живописи">`, получился единичный локальный diff.

### Testing
- Выполнены автоматические проверки: `git diff -- pages/home.html`, `git status --short && git branch --show-current`, и `git add pages/home.html && git commit -m "Replace home hero placeholder with poster image"`, все команды выполнились успешно, и создан PR с таргетом на `main`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd40e0cff483229019459cb034122c)