### PR TITLE
Use poster image in home hero visual

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -19,8 +19,7 @@
         <div class="hero-visual">
             <div class="hero-visual-frame">
                 <div class="hero-visual-inner">
-                    <i class="fa-solid fa-image"></i>
-                    <span>Фрагмент живописи</span>
+                    <img src="assets/works/assets/poster_correct_home.webp" alt="Фрагмент живописи">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Motivation
- Replace the placeholder icon and caption in the home hero with the actual poster image so the landing section shows the exhibition visual.

### Description
- In `pages/home.html` the icon and caption (`<i class="fa-solid fa-image"></i>` and `<span>Фрагмент живописи</span>`) were replaced with an `<img src="assets/works/assets/poster_correct_home.webp" alt="Фрагмент живописи">` element.

### Testing
- No automated tests were added or run for this small markup change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd40e0cff483229019459cb034122c)