### PR TITLE
Заменить «Цикл» на «Раздел» в карточках каталога работ

### DIFF
--- a/app.js
+++ b/app.js
@@ -611,7 +611,7 @@ function createCatalogCard(work) {
             imageClass: 'catalog-thumb'
         })}
         <h4>${escapeHtml(work.title)}</h4>
-        <div class="catalog-cycle">Цикл: ${escapeHtml(label)}</div>
+        <div class="catalog-cycle">Раздел: ${escapeHtml(label)}</div>
         <span class="catalog-meta" style="color: var(--text-muted);">${escapeHtml(meta || 'Без даты')}</span>
         <div class="catalog-technique" style="color: var(--text-muted);">${escapeHtml(techLine || 'Данные уточняются')}</div>
     `;

--- a/works-runtime.js
+++ b/works-runtime.js
@@ -257,7 +257,7 @@
                         </div>
                     </div>
                     <h4>${escapeHtml(work.title)}</h4>
-                    <div class="catalog-cycle">Цикл: ${escapeHtml(categoryLabel)}</div>
+                    <div class="catalog-cycle">Раздел: ${escapeHtml(categoryLabel)}</div>
                     <span class="catalog-meta" style="color: var(--text-muted);">${escapeHtml(work.year)}</span>
                     <div class="catalog-technique" style="color: var(--text-muted);">${escapeHtml(work.technique)} · ${escapeHtml(work.size)}</div>
                 </a>


### PR DESCRIPTION
### Motivation
- Обновить текстовую метку на карточках каталога работ на странице `/works`, чтобы вместо `Цикл:` отображалось `Раздел:`.

### Description
- В `app.js` и `works-runtime.js` заменён фрагмент `<div class="catalog-cycle">Цикл: …</div>` на `<div class="catalog-cycle">Раздел: …</div>` для рендера карточек.

### Testing
- Проверено через `rg -n "Цикл:|Раздел:" app.js works-runtime.js`, которое показало только ожидаемые новые вхождения; просмотр изменённых строк выполнен командой `nl -ba app.js | sed -n '606,620p'` и `nl -ba works-runtime.js | sed -n '254,266p'`, вывод соответствует ожидаемому.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4c51b1348322a855dab80e262900)