### PR TITLE
Replace homepage selected-work placeholders with four real paintings

### DIFF
--- a/09_SOURCE_JSON/pages/home.json
+++ b/09_SOURCE_JSON/pages/home.json
@@ -53,24 +53,36 @@
     },
     "items": [
       {
-        "title": "Северный пейзаж",
-        "meta": "А.Л. Овчинников · 1998 · 80 x 120 см",
-        "route": "/works/severniy-peyzazh"
+        "title": "Емельян Пугачёв / эскиз к дипломной работе /",
+        "meta": "А.Л. Овчинников · 1984",
+        "route": "/works/emelyan-pugachev-eskiz-k-diplomnoy-rabote",
+        "image": "assets/works/thumbs/033.jpg",
+        "category": "history",
+        "label": "Историческая тема"
       },
       {
-        "title": "Вечерний свет. Вологда",
-        "meta": "А.Л. Овчинников · 2005 · 60 x 90 см",
-        "route": "/works/vecherniy-svet-vologda"
+        "title": "Лесная часовня (этюд)",
+        "meta": "А.Л. Овчинников · 1984 · к/м",
+        "route": "/works/lesnaya-chasovnya-etyud",
+        "image": "assets/works/thumbs/108.jpg",
+        "category": "history",
+        "label": "Историческая тема"
       },
       {
-        "title": "Зимний день в Петербурге",
-        "meta": "А.Л. Овчинников · 2010 · 50 x 70 см",
-        "route": "/works/zimniy-den-v-peterburge"
+        "title": "Старые сени",
+        "meta": "А.Л. Овчинников · 1989 · 100 × 150 см",
+        "route": "/works/starye-seni",
+        "image": "assets/works/thumbs/034.jpg",
+        "category": "interior",
+        "label": "Камерный мир"
       },
       {
-        "title": "Нижегородские дали",
-        "meta": "А.Л. Овчинников · 2012 · 70 x 100 см",
-        "route": "/works/nizhegorodskie-dali"
+        "title": "Кабанчик",
+        "meta": "А.Л. Овчинников · 2010",
+        "route": "/works/kabanchik",
+        "image": "assets/works/thumbs/013.jpg",
+        "category": "north",
+        "label": "Русский Север"
       }
     ]
   },

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,5 +1,5 @@
 (function bootstrapApp() {
-    const BUILD_ID = '2026-04-13-works-runtime-v2';
+    const BUILD_ID = '2026-04-13-home-selected-works-v3';
 
     function withBuildId(path) {
         const separator = path.includes('?') ? '&' : '?';
@@ -74,6 +74,7 @@
             }
             return null;
         })
+        .then(() => loadScript('home-selected-works-sync.js'))
         .then(() => loadScript('artist-route-map.js'))
         .then(() => loadScript('app.js'))
         .then(() => loadScript('works-runtime.js'))

--- a/home-selected-works-sync.js
+++ b/home-selected-works-sync.js
@@ -1,0 +1,106 @@
+(function initHomeSelectedWorksSync() {
+  const HOME_JSON_PATH = '09_SOURCE_JSON/pages/home.json';
+  const CARD_SELECTOR = '#page-home .home-works-section .works-grid .work-card';
+
+  const categoryLabels = {
+    north: 'Русский Север',
+    city: 'Русский город',
+    history: 'Историческая тема',
+    interior: 'Камерный мир',
+    volga: 'Волга и Юг',
+    graphics: 'Графика'
+  };
+
+  function applyItem(card, item) {
+    if (!card || !item) return;
+
+    const title = card.querySelector('h4');
+    const meta = card.querySelector('.work-meta');
+    const label = card.querySelector('.artwork-label');
+    const imageWrap = card.querySelector('.work-image');
+    const imageInner = card.querySelector('.work-image-inner');
+
+    if (title && item.title) title.textContent = item.title;
+    if (meta && item.meta) meta.textContent = item.meta;
+
+    const route = item.route || card.getAttribute('data-route') || '';
+    if (route) {
+      card.setAttribute('data-route', route);
+      card.setAttribute('href', `#${route}`);
+    }
+
+    const category = item.category || card.getAttribute('data-category') || '';
+    if (category) {
+      card.setAttribute('data-category', category);
+    }
+
+    const labelText = item.label || categoryLabels[category] || '';
+    if (label && labelText) {
+      label.textContent = labelText;
+    }
+
+    if (!imageInner) return;
+
+    let image = imageInner.querySelector('img.home-selected-work-image');
+
+    if (item.image) {
+      if (!image) {
+        image = document.createElement('img');
+        image.className = 'home-selected-work-image';
+        image.loading = 'lazy';
+        image.decoding = 'async';
+        image.style.display = 'block';
+        image.style.width = '100%';
+        image.style.height = '100%';
+        image.style.objectFit = 'cover';
+        image.style.borderRadius = 'inherit';
+        imageInner.insertBefore(image, imageInner.firstChild);
+      }
+
+      image.src = item.image;
+      image.alt = item.title || '';
+
+      if (imageWrap) {
+        imageWrap.classList.add('has-image');
+      }
+    } else if (image) {
+      image.remove();
+
+      if (imageWrap) {
+        imageWrap.classList.remove('has-image');
+      }
+    }
+  }
+
+  function syncHomeSelectedWorks(retries = 10) {
+    const cards = document.querySelectorAll(CARD_SELECTOR);
+
+    if (!cards.length) {
+      if (retries > 0) {
+        setTimeout(() => syncHomeSelectedWorks(retries - 1), 60);
+      }
+      return;
+    }
+
+    fetch(HOME_JSON_PATH, { cache: 'no-store' })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load ${HOME_JSON_PATH}: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((home) => {
+        const items = Array.isArray(home?.worksTeaser?.items) ? home.worksTeaser.items : [];
+        cards.forEach((card, index) => applyItem(card, items[index]));
+      })
+      .catch((error) => {
+        console.error('Home selected works sync error:', error);
+      });
+  }
+
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', () => syncHomeSelectedWorks(), { once: true });
+  } else {
+    syncHomeSelectedWorks();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -27,6 +27,6 @@
     <div id="pages-root"></div>
     <div id="component-footer"></div>
 
-    <script src="bootstrap.js?v=2026-04-13-works-runtime-v1"></script>
+    <script src="bootstrap.js?v=2026-04-13-home-selected-works-v3"></script>
 </body>
 </html>


### PR DESCRIPTION
### Что сделано
- заменён набор из 4 карточек в блоке «Избранные работы» на главной странице
- добавлены реальные маршруты, подписи и метаданные для работ:
  - `#/works/emelyan-pugachev-eskiz-k-diplomnoy-rabote`
  - `#/works/lesnaya-chasovnya-etyud`
  - `#/works/starye-seni`
  - `#/works/kabanchik`
- добавлен небольшой runtime-скрипт `home-selected-works-sync.js`, который после `content-sync` подставляет реальные изображения и метаданные из JSON
- обновлён `09_SOURCE_JSON/pages/home.json` под новый набор работ
- обновлён `bootstrap.js` и cache-busting query для загрузки нового скрипта

### Почему так
- блок на главной раньше имел только градиентные заглушки
- существующий `content-sync.js` синхронизировал для этих карточек только текст и route, но не изображения
- отдельный runtime-sync для этого блока позволяет не возвращать контент обратно в HTML и оставить данные в JSON

### Проверить
- на главной в секции «Избранные работы» отображаются 4 реальные миниатюры
- карточки открывают правильные маршруты работ
- подписи циклов обновлены вместе с карточками
