### PR TITLE
Включить показ «Северная поветь» (id:1)

### DIFF
--- a/09_SOURCE_JSON/shared/works-catalog-1-110.json
+++ b/09_SOURCE_JSON/shared/works-catalog-1-110.json
@@ -16,7 +16,7 @@
     "resolvedSourceFile": "",
     "image": "assets/works/full/001.jpg",
     "thumbnail": "assets/works/thumbs/001.jpg",
-    "missingImage": true,
+    "missingImage": false,
     "batch": "core_1_70",
     "dataCompleteness": "mixed"
   },

--- a/09_SOURCE_JSON/shared/works-image-map.json
+++ b/09_SOURCE_JSON/shared/works-image-map.json
@@ -4,7 +4,7 @@
     "thumbnail": "assets/works/thumbs/001.jpg",
     "sourceFile": "2_2.jpg",
     "resolvedSourceFile": "",
-    "missingImage": true
+    "missingImage": false
   },
   "2": {
     "image": "assets/works/full/002.jpg",


### PR DESCRIPTION
### Motivation
- Разрешить показ работы «Северная поветь» на сайте — файлы изображений уже заменены в `assets`, поэтому нужно снять флаги отсутствия изображений в исходных JSON, чтобы runtime использовал `assets/works/thumbs/001.jpg` и `assets/works/full/001.jpg`.

### Description
- В двух JSON-файлах изменён флаг `missingImage` с `true` на `false` для работы `id: 1`: в `09_SOURCE_JSON/shared/works-catalog-1-110.json` и в ключе `"1"` файла `09_SOURCE_JSON/shared/works-image-map.json`; больше ничего не менялось, формат JSON сохранён и изменения закоммичены.

### Testing
- Выполнены и успешно прошли проверки `git diff -- 09_SOURCE_JSON/shared/works-catalog-1-110.json 09_SOURCE_JSON/shared/works-image-map.json` и `git show --name-only --oneline HEAD`, подтверждающие, что изменены только эти два файла и только требуемые флаги.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c9f14c188322b69e3fa8aa289a0a)