### PR TITLE
Hotfix: disable animated runtime loading

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,5 +1,5 @@
 (function bootstrapApp() {
-    const BUILD_ID = '2026-04-20-animated-work-v3';
+    const BUILD_ID = '2026-04-20-hotfix-v2';
 
     function withBuildId(path) {
         const separator = path.includes('?') ? '&' : '?';
@@ -78,7 +78,6 @@
         .then(() => loadScript('artist-route-map.js'))
         .then(() => loadScript('app.js'))
         .then(() => loadScript('works-runtime.js'))
-        .then(() => loadScript('works-animated-runtime.js'))
         .catch((error) => {
             console.error('Bootstrap error:', error);
         });

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <div id="pages-root"></div>
     <div id="component-footer"></div>
 
-    <script src="bootstrap.js?v=2026-04-20-animated-work-v3"></script>
+    <script src="bootstrap.js?v=2026-04-20-hotfix-v2"></script>
     <script src="work-author-overrides.js?v=2026-04-19-lev-author-fix"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Восстановить стабильную загрузку сайта, отключив загрузку проблемного анимированного рантайма и переключив сборку на `2026-04-20-hotfix-v2`.

### Description
- Обновлён `bootstrap.js` — заменён `BUILD_ID` на `2026-04-20-hotfix-v2` и удалена строка `.then(() => loadScript('works-animated-runtime.js'))`, и обновлён `index.html` для загрузки `bootstrap.js?v=2026-04-20-hotfix-v2`; других файлов не трогал и `works-animated-runtime.js` не удалял.

### Testing
- Выполнена проверка изменений через дифф по файлам `bootstrap.js` и `index.html` и просмотр содержимого файлов для подтверждения корректного `BUILD_ID` и удаления вызова загрузки анимированного рантайма, обновление записано в локальном репозитории успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fbadb9c083228b6cf3be53e6b82b)