### PR TITLE
Fix `/works/*` slug normalization and add compatibility aliases for work 70

### DIFF
--- a/app.js
+++ b/app.js
@@ -128,7 +128,9 @@ const legacyWorkAliases = {
     'masterskaya-utro': 31,
     'severnaya-derevnya-gravyura': 66,
     'istoricheskiy-motiv': 33,
-    'vasilsursk': 16
+    'vasilsursk': 16,
+    'lodka-u-kirpichnoi-naberezhnoi': 70,
+    'lodka-u-kirpichnoj-naberezhnoj': 70
 };
 
 const routeMap = {
@@ -206,7 +208,7 @@ function setHashPath(path) {
 }
 
 function isWorkPath(path) {
-    return /^\/works\/.+$/.test(path);
+    return /^\/works\/.+\/?$/.test(path);
 }
 
 function isValidPath(path) {
@@ -250,10 +252,23 @@ function fetchJson(path) {
 }
 
 function getWorkBySlug(slug) {
-    if (worksSlugMap.has(slug)) {
-        return worksSlugMap.get(slug);
+    const rawSlug = String(slug || '').trim().replace(/^\/+|\/+$/g, '');
+    const decodedSlug = (() => {
+        try {
+            return decodeURIComponent(rawSlug);
+        } catch (error) {
+            return rawSlug;
+        }
+    })();
+    const normalizedSlug = slugifyRu(decodedSlug);
+
+    if (worksSlugMap.has(decodedSlug)) {
+        return worksSlugMap.get(decodedSlug);
     }
-    const legacyId = legacyWorkAliases[slug];
+    if (worksSlugMap.has(normalizedSlug)) {
+        return worksSlugMap.get(normalizedSlug);
+    }
+    const legacyId = legacyWorkAliases[decodedSlug] || legacyWorkAliases[normalizedSlug];
     if (legacyId) {
         return worksDB.find((work) => work.id === legacyId) || null;
     }
@@ -1039,7 +1054,7 @@ function renderPath(path) {
 
     if (isWorkPath(safePath)) {
         activatePage('page-work-single');
-        const slug = safePath.replace('/works/', '');
+        const slug = safePath.replace('/works/', '').replace(/\/+$/g, '');
         const ok = showWorkPage(slug);
         if (!ok) return;
 

--- a/works-runtime.js
+++ b/works-runtime.js
@@ -20,6 +20,9 @@
         bySlug: new Map(),
         loadPromise: null
     };
+    const compatibilityAliasesById = {
+        70: ['lodka-u-kirpichnoi-naberezhnoi', 'lodka-u-kirpichnoj-naberezhnoj']
+    };
 
     function withBuildId(path) {
         const separator = path.includes('?') ? '&' : '?';
@@ -169,11 +172,15 @@
         const aliases = Array.isArray(runtimeEntry.aliases)
             ? Array.from(new Set(runtimeEntry.aliases.map((alias) => slugifyRu(alias)).filter(Boolean).filter((alias) => alias !== slug)))
             : [];
+        const compatibilityAliases = Array.isArray(compatibilityAliasesById[Number(record.id)])
+            ? compatibilityAliasesById[Number(record.id)].map((alias) => slugifyRu(alias)).filter(Boolean)
+            : [];
+        const mergedAliases = Array.from(new Set([...aliases, ...compatibilityAliases].filter((alias) => alias !== slug)));
 
         return {
             id: Number(record.id) || 0,
             slug,
-            aliases,
+            aliases: mergedAliases,
             title: record.title || `Работа ${record.id}`,
             year: String(record.year || '').trim() || '—',
             place: String(record.place || '').trim() || '—',
@@ -232,7 +239,8 @@
 
     function getRouteSlug(path) {
         const match = String(path || '').match(/^\/works\/([^/?#]+)/);
-        return match ? decodeURIComponent(match[1]) : '';
+        if (!match) return '';
+        return decodeURIComponent(match[1]).replace(/^\/+|\/+$/g, '');
     }
 
     function getWorkBySlug(slug) {


### PR DESCRIPTION
### Motivation
- Incoming direct links to work pages could fail because of trailing slashes, URL-encoded slugs, or small transliteration variants of the same title (e.g. the "Лодка у кирпичной набережной" slug). 
- The runtime renderer and router used slightly different slug handling which made some legacy/variant slugs unresolved.

### Description
- Relaxed work-route detection in `app.js` to accept optional trailing slash by changing `isWorkPath` to `^/works/.+/?$`.
- Hardened `getWorkBySlug` in `app.js` to trim leading/trailing slashes, safely `decodeURIComponent`, and fall back to a normalized slug (via `slugifyRu`) when resolving work entries.
- Trim trailing slashes from extracted slugs in `renderPath` before calling `showWorkPage` in `app.js`.
- Added backward-compatible legacy aliases for work id `70` (`lodka-u-kirpichnoi-naberezhnoi`, `lodka-u-kirpichnoj-naberezhnoj`) to the router's `legacyWorkAliases` map in `app.js`.
- Added the same compatibility aliases to `works-runtime.js` via a `compatibilityAliasesById` table and merged them with runtime-provided aliases so the runtime renderer resolves the same variants; also normalized `getRouteSlug` to strip extra slashes after decoding.

### Testing
- Ran `node --check app.js` and the check completed successfully.
- Ran `node --check works-runtime.js` and the check completed successfully.
- Verified compatibility alias strings are present in both `app.js` and `works-runtime.js` using a small Node script, which reported the expected aliases were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fe9f1664832299cf01fd82cfc111)