### PR TITLE
Fix home hero poster to use non-cropped image element

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -19,7 +19,7 @@
         <div class="hero-visual">
             <div class="hero-visual-frame">
                 <div class="hero-visual-inner">
-                    <img src="assets/posters/poster_correct_home.webp" alt="Фрагмент живописи">
+                    <img src="assets/posters/poster_correct_home.webp" alt="Александр Львович Овчинников. Пространство памяти" class="home-hero-poster">
                 </div>
             </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -296,20 +296,28 @@
             align-items: center;
             justify-content: center;
             position: relative;
-            overflow: hidden;
             border: 1px solid var(--border-dark);
             opacity: 0;
             animation: fadeUp 0.8s 0.6s forwards;
         }
         .hero-visual-inner {
-            position: absolute;
-            inset: 16px;
+            position: static;
+            inset: auto;
             border: 1px solid rgba(255,255,255,0.06);
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: center;
             gap: 16px;
+            padding: 16px;
+            width: 100%;
+        }
+        .home-hero-poster {
+            width: 100%;
+            height: auto;
+            max-height: 78vh;
+            object-fit: contain;
+            display: block;
         }
         .hero-visual-inner i {
             font-size: 56px;


### PR DESCRIPTION
### Motivation
- The hero visual on the home page used a decorative/offset layout that cropped the poster image, so the poster should be shown as a full, non-cropped image while preserving JSON-driven content rules in `ARCHITECTURE.md`.

### Description
- Replaced the existing hero image element alt text and added class `home-hero-poster` in `pages/home.html` to use `assets/posters/poster_correct_home.webp` with the requested `alt` value.
- Updated `styles.css` to remove the clipping behavior from the visual frame and adjusted `.hero-visual-inner` to allow the image to layout naturally.
- Added `.home-hero-poster` styles in `styles.css` with `width: 100%`, `height: auto`, `max-height: 78vh`, and `object-fit: contain` to ensure the poster displays fully and is not cropped.
- Files changed: `pages/home.html`, `styles.css` (no changes to `09_SOURCE_JSON/pages/home.json`).

### Testing
- Verified `ARCHITECTURE.md` was consulted with `sed -n '1,220p' ARCHITECTURE.md` and the JSON editing rule was followed, which succeeded.
- Inspected the updated markup with `sed -n '1,260p' pages/home.html` and confirmed the new `img` element and attributes were present, which succeeded.
- Searched styles and markup with `rg -n "home-hero-poster|hero-visual-frame|hero-visual-inner|poster_correct_home"` to confirm CSS and HTML updates, which succeeded.
- Performed a diff check of the modified files to confirm only the intended changes were applied, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ca824740832294096d7e979992b2)