### PR TITLE
Подключение Яндекс.Метрики (108720075) для SPA hash-router

### DIFF
--- a/app.js
+++ b/app.js
@@ -160,6 +160,7 @@ const contactConfig = {
     submitUrl: 'https://formsubmit.co/ajax/od03@yandex.ru',
     subjectPrefix: 'Пространство памяти'
 };
+const METRIKA_ID = 108720075;
 
 // ══════════════════════════════════════════════
 // DOM REFS
@@ -238,6 +239,12 @@ function escapeHtml(value) {
 function withBuildId(path) {
     const separator = path.includes('?') ? '&' : '?';
     return `${path}${separator}build=${encodeURIComponent(WORKS_BUILD_ID)}`;
+}
+
+function metrikaHit() {
+    if (typeof window.ym === 'function') {
+        ym(METRIKA_ID, 'hit', window.location.href);
+    }
 }
 
 function fetchJson(path) {
@@ -1044,6 +1051,7 @@ function renderPath(path) {
         document.title = getWorkTitle(slug);
         reinitReveals();
         stopWorkshopLoop();
+        metrikaHit();
         return;
     }
 
@@ -1062,6 +1070,8 @@ function renderPath(path) {
     } else {
         stopWorkshopLoop();
     }
+
+    metrikaHit();
 }
 
 function navigateTo(path, updateHash) {

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,5 +1,5 @@
 (function bootstrapApp() {
-    const BUILD_ID = '2026-04-20-hotfix-v2';
+    const BUILD_ID = '2026-04-22-metrika-spa-v1';
 
     function withBuildId(path) {
         const separator = path.includes('?') ? '&' : '?';

--- a/index.html
+++ b/index.html
@@ -15,11 +15,30 @@
     <link rel="stylesheet" href="artist-route-map-fix.css?v=2026-04-18-home-hero-v3">
     <link rel="stylesheet" href="works-runtime.css?v=2026-04-18-home-hero-v3">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" />
+    <script type="text/javascript">
+        (function(m,e,t,r,i,k,a){
+            m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+            m[i].l=1*new Date();
+            for (let j = 0; j < document.scripts.length; j++) {
+                if (document.scripts[j].src === r) return;
+            }
+            k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a);
+        })(window, document, 'script', 'https://mc.yandex.ru/metrika/tag.js', 'ym');
+
+        ym(108720075, 'init', {
+            defer: true,
+            clickmap: true,
+            trackLinks: true,
+            accurateTrackBounce: true,
+            webvisor: true
+        });
+    </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
 </head>
 <body>
+    <noscript><div><img src="https://mc.yandex.ru/watch/108720075" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
     <canvas id="canvas"></canvas>
 
     <div id="component-header"></div>
@@ -27,7 +46,7 @@
     <div id="pages-root"></div>
     <div id="component-footer"></div>
 
-    <script src="bootstrap.js?v=2026-04-20-hotfix-v2"></script>
+    <script src="bootstrap.js?v=2026-04-22-metrika-spa-v1"></script>
     <script src="work-author-overrides.js?v=2026-04-19-lev-author-fix"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Добавить корректное отслеживание pageview для SPA (hash-router) через Яндекс.Метрику с минимальным вмешательством в текущую структуру сайта.
- Обеспечить единичную отправку просмотра после реальной смены маршрута и сохранить существующий порядок загрузки скриптов/страниц.

### Description
- `index.html`: добавлен script-кусок Метрики в `<head>` и `noscript`-часть в `<body>`, инициализация `ym(108720075, 'init', {...})` с параметрами `defer: true`, `webvisor: true`, `clickmap: true`, `trackLinks: true`, `accurateTrackBounce: true`, при этом не добавлялись `ecommerce`, `referrer`, `url` или `ssr`.
- `app.js`: введена константа `METRIKA_ID = 108720075`, добавлен helper `metrikaHit()` который вызывает `ym(METRIKA_ID, 'hit', window.location.href)` при наличии функции `ym`, и встроены вызовы `metrikaHit()` в `renderPath(path)` — в ветке work-detail перед `return` и в обычной ветке в конце, чтобы посылать ровно один hit после смены маршрута.
- `bootstrap.js`: аккуратное обновление `BUILD_ID` (`2026-04-20-hotfix-v2` → `2026-04-22-metrika-spa-v1`) и синхронизация query у подключения `bootstrap.js` в `index.html` для корректного cache-busting после правок.

### Testing
- Запуск синтаксической проверки: `node --check app.js` — успешно.
- Запуск синтаксической проверки: `node --check bootstrap.js` — успешно.
- Проверка статуса изменений/диффа в локальном репозитории была выполнена и показала модификации `index.html`, `app.js`, `bootstrap.js` (автоматические git-операции завершились успешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e927327f5c8322a49af71e713a4c20)