### PR TITLE
Add Yandex verification meta tag to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <!-- PROTECTED: meta type -->
     <meta name="type" value="app" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="yandex-verification" content="6d118d917b1088ac" />
     <title>Александр Львович Овчинников — художник</title>
     <meta name="description" content="Официальный цифровой архив Александра Львовича Овчинникова: живопись, графика, линогравюра, биография, произведения, Русский Север, Волга, русский город, интерьер, предметный мир и материалы о наследии художника.">
     <link rel="canonical" href="https://ovchinnikov-al.art/">


### PR DESCRIPTION
### Motivation
- Добавить метатег для верификации сайта в Яндексе в `<head>` главной страницы.

### Description
- В `index.html` добавлен `<meta name="yandex-verification" content="6d118d917b1088ac" />` непосредственно после метатега `viewport`.

### Testing
- Выполнены `git status --short`, `git add index.html && git commit -m "Add Yandex verification meta tag to homepage head"`, и проверка содержимого через `nl -ba index.html | sed -n '1,25p'`, все успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6639018208322b28266438cdbd753)